### PR TITLE
fix:#80 meta data db에 맞춰 수정 및 전송 값 value -> name으로 변경

### DIFF
--- a/src/features/user-meta-data/data/user-meta-data.ts
+++ b/src/features/user-meta-data/data/user-meta-data.ts
@@ -38,7 +38,7 @@ export const typeData: SelectBoxType[] = [
 
 export const academicData: SelectBoxType[] = [
   {
-    name: '고교 졸업 이하',
+    name: '고졸',
     value: '고교 졸업 이하',
     // value: 'ACADEMIC1', => 사람인 API 연결되면 바꿀 예정
   },
@@ -48,30 +48,30 @@ export const academicData: SelectBoxType[] = [
     // value: 'ACADEMIC2',=> 사람인 API 연결되면 바꿀 예정
   },
   {
-    name: '대학 졸업(2,3년제)',
+    name: '대졸(2~3년)',
     value: '대학 졸업(2,3년제)',
     // value: 'ACADEMIC3',=> 사람인 API 연결되면 바꿀 예정
   },
   {
-    name: '대학교 졸업(4년제)',
+    name: '대졸(4년)',
     value: '대학교 졸업(4년제)',
     // value: 'ACADEMIC4',=> 사람인 API 연결되면 바꿀 예정
   },
   {
-    name: '대학원 석사 졸업',
+    name: '석사',
     value: '대학원 석사 졸업',
     // value: 'ACADEMIC5',=> 사람인 API 연결되면 바꿀 예정
   },
   {
-    name: '대학원 박사 졸업',
+    name: '박사',
     value: '대학원 박사 졸업',
     // value: 'ACADEMIC6',=> 사람인 API 연결되면 바꿀 예정
   },
-  {
-    name: '박사 졸업 이상',
-    value: '박사 졸업 이상',
-    // value: 'ACADEMIC7',
-  },
+  // {
+  //   name: '박사 졸업 이상',
+  //   value: '박사 졸업 이상',
+  //   // value: 'ACADEMIC7',
+  // },
 ];
 
 export const jobData: SelectBoxType[] = [

--- a/src/features/user-meta-data/select-box.tsx
+++ b/src/features/user-meta-data/select-box.tsx
@@ -1,10 +1,12 @@
 import { DEFAULT } from '@/constants/user-meta-data-constants';
 import type { SelectBoxType } from '@/types/select-box';
 
+//@TODO:
+// 사람인 api 연결 시 현재 select box의 선택값이 name으로 되어있지만 value로 수정할 것
 type Props = {
   options: SelectBoxType[];
   selected: string;
-  onSelect: (value: SelectBoxType['value']) => void;
+  onSelect: (value: SelectBoxType['name']) => void; //@TODO: 추후 type 'value'로 수정
 };
 
 const SelectBox = ({ options, selected = DEFAULT, onSelect }: Props) => {
@@ -16,7 +18,7 @@ const SelectBox = ({ options, selected = DEFAULT, onSelect }: Props) => {
     <select value={selected} onChange={handleSelect}>
       <option value={DEFAULT}>선택</option>
       {options.map((option) => (
-        <option key={`option_${option.value}`} value={option.value}>
+        <option key={`option_${option.name}`} value={option.name}>
           {option.name}
         </option>
       ))}


### PR DESCRIPTION
## 💡 관련이슈

- #80

## 🍀 작업 요약

1.
- select box의 선택 값이 'value'로 들어가고 있어서 다른 db column에서 사용하는 값과 일치하지 않음
- 왜냐하면 지역의 경우 value는 영어이고, 다른 db column에서는 한글 이름을 사용하고 있음
- 따라서 select box의 선택 값을 value -> 'name'으로 수정
2.
- 학력 정보에 대한 데이터가 일치하지 않음
- 현재는 사람인 기준으로 학력 정보가 작성되어 있지만
- MOCK_DATA는 공공 api 기준으로 작성되어 있기 때문
- 사람인 API를 연결하기 전까진 공공 기관 api에 맞춰 수정

## 💬 리뷰 요구 사항

- 창연님 이제 데이터 잘 들어오는지 확인 부탁드립니다 !

## 💛 미리보기


### ✔️ 이슈 닫기

Closes #80 
