### PR TITLE
Refactor/#147 modal component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ const RootLayout = ({
       <body className={suit.className}>
         <AuthProvider>
           <RQProvider>
-            <div className='min-h-[100dvh]s mx-[auto] flex'>{children}</div>
+            <div className='mx-[auto] flex min-h-[100dvh]'>{children}</div>
           </RQProvider>
         </AuthProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
-import clsx from 'clsx';
 import AuthProvider from '@/provider/auth-provider';
 import { RQProvider } from '@/provider/react-query-provider';
 import './global-style.css';
@@ -22,10 +21,10 @@ const RootLayout = ({
 }>) => {
   return (
     <html lang='ko'>
-      <body>
+      <body className={suit.className}>
         <AuthProvider>
           <RQProvider>
-            <div className={clsx('mx-[auto] flex min-h-[100dvh]', suit.className)}>{children}</div>
+            <div className='min-h-[100dvh]s mx-[auto] flex'>{children}</div>
           </RQProvider>
         </AuthProvider>
       </body>

--- a/src/components/icons/close.tsx
+++ b/src/components/icons/close.tsx
@@ -1,0 +1,10 @@
+const Close = () => {
+  return (
+    <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+      <path d='M18 6L6 18' stroke='#D1D5DB' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
+      <path d='M6 6L18 18' stroke='#D1D5DB' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
+    </svg>
+  );
+};
+
+export default Close;

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -47,8 +47,10 @@ const Modal = ({ portalRoot, modalId, children, className }: Props) => {
   return createPortal(
     <div className='fixed inset-0 z-50 flex items-center justify-center overflow-y-auto'>
       <div className='fixed inset-0 bg-black opacity-70' />
-      {/* 모달 width 변경 - 빠른 재조정 시급 */}
-      <div ref={modalContentRef} className='relative w-full max-w-[434px] flex-col rounded-3xl bg-white p-8'>
+      <div
+        ref={modalContentRef}
+        className='relative max-h-[600px] w-full max-w-[434px] flex-col overflow-scroll rounded-3xl bg-white p-8 scrollbar-hide'
+      >
         <button onClick={() => toggleModal(modalId)} className='absolute right-4 top-4'>
           <Close />
         </button>

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -3,6 +3,7 @@
 import { useModalStore } from '@/store/use-modal-store';
 import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import Close from '@/components/icons/close';
 
 type Props = {
   modalId: string;
@@ -47,9 +48,9 @@ const Modal = ({ portalRoot, modalId, children, className }: Props) => {
     <div className='fixed inset-0 z-50 flex items-center justify-center overflow-y-auto'>
       <div className='fixed inset-0 bg-black opacity-70' />
       {/* 모달 width 변경 - 빠른 재조정 시급 */}
-      <div ref={modalContentRef} className='relative w-full max-w-[600px] flex-col rounded-lg bg-white p-8'>
+      <div ref={modalContentRef} className='relative w-full max-w-[434px] flex-col rounded-3xl bg-white p-8'>
         <button onClick={() => toggleModal(modalId)} className='absolute right-4 top-4'>
-          X
+          <Close />
         </button>
         <div className={className}>{children}</div>
       </div>

--- a/src/features/resume/draft-resume-item.tsx
+++ b/src/features/resume/draft-resume-item.tsx
@@ -1,0 +1,28 @@
+import Trash from '@/components/icons/trash';
+import Typography from '@/components/ui/typography';
+import { formatDate } from '@/utils/format-date';
+import { Resume } from '@prisma/client';
+
+type Props = {
+  resume: Resume;
+  onDeleteClick: (resumeId: number) => void;
+  onDraftResumeClick: (resume: Resume) => void;
+};
+
+const DraftResumeItem = ({ resume, onDeleteClick, onDraftResumeClick }: Props) => {
+  return (
+    <li key={resume.id} className='flex flex-col'>
+      <div className='flex justify-between'>
+        <Typography color='gray-500'>{formatDate({ input: resume.createdAt })}</Typography>
+        <button onClick={() => onDeleteClick(resume.id)}>
+          <Trash />
+        </button>
+      </div>
+      <button className='text-left font-bold text-cool-gray-900' onClick={() => onDraftResumeClick(resume)}>
+        {resume.title}
+      </button>
+    </li>
+  );
+};
+
+export default DraftResumeItem;

--- a/src/features/resume/draft-resume-item.tsx
+++ b/src/features/resume/draft-resume-item.tsx
@@ -18,7 +18,7 @@ const DraftResumeItem = ({ resume, onDeleteClick, onDraftResumeClick }: Props) =
           <Trash />
         </button>
       </div>
-      <button className='text-left font-bold text-cool-gray-900' onClick={() => onDraftResumeClick(resume)}>
+      <button className='w-fit font-bold text-cool-gray-900' onClick={() => onDraftResumeClick(resume)}>
         {resume.title}
       </button>
     </li>

--- a/src/features/resume/draft-resume-item.tsx
+++ b/src/features/resume/draft-resume-item.tsx
@@ -14,11 +14,15 @@ const DraftResumeItem = ({ resume, onDeleteClick, onDraftResumeClick }: Props) =
     <li key={resume.id} className='flex flex-col'>
       <div className='flex justify-between'>
         <Typography color='gray-500'>{formatDate({ input: resume.createdAt })}</Typography>
-        <button onClick={() => onDeleteClick(resume.id)}>
+        <button aria-label={`${resume.title} 임시저장 자소서 삭제`} onClick={() => onDeleteClick(resume.id)}>
           <Trash />
         </button>
       </div>
-      <button className='w-fit font-bold text-cool-gray-900' onClick={() => onDraftResumeClick(resume)}>
+      <button
+        aria-label={`${resume.title} 임시저장 자소서 불러오기`}
+        onClick={() => onDraftResumeClick(resume)}
+        className='w-fit font-bold text-cool-gray-900'
+      >
         {resume.title}
       </button>
     </li>

--- a/src/features/resume/draft-resume-item.tsx
+++ b/src/features/resume/draft-resume-item.tsx
@@ -1,7 +1,7 @@
 import Trash from '@/components/icons/trash';
 import Typography from '@/components/ui/typography';
 import { formatDate } from '@/utils/format-date';
-import { Resume } from '@prisma/client';
+import type { Resume } from '@prisma/client';
 
 type Props = {
   resume: Resume;

--- a/src/features/resume/draft-resumes-modal.tsx
+++ b/src/features/resume/draft-resumes-modal.tsx
@@ -22,7 +22,10 @@ const DraftResumesModal = ({ draftResumeList, isError, onLoadDraft, activeResume
   const { mutate: deleteResumeMutate } = useDeleteResumeMutation();
 
   const handleDeleteResume = (resumeId: number) => {
-    deleteResumeMutate(resumeId);
+    if (window.confirm('자기소개서를 정말로 삭제하시겠습니까?')) {
+      deleteResumeMutate(resumeId);
+    }
+
     if (activeResumeId === resumeId) {
       setResumeId(null);
     }

--- a/src/features/resume/draft-resumes-modal.tsx
+++ b/src/features/resume/draft-resumes-modal.tsx
@@ -45,7 +45,7 @@ const DraftResumesModal = ({ draftResumeList, isError, onLoadDraft, activeResume
         </Typography>
       </div>
       {!isError && draftResumeList?.length === 0 ? (
-        <Typography>임시 저장된 자기소개서가 없습니다</Typography>
+        <Typography color='gray-500'>임시 저장된 자기소개서가 없습니다</Typography>
       ) : (
         <ul className='flex flex-col gap-4'>
           {draftResumeList?.map((resume) => {

--- a/src/features/resume/draft-resumes-modal.tsx
+++ b/src/features/resume/draft-resumes-modal.tsx
@@ -5,10 +5,8 @@ import Modal from '@/components/ui/modal';
 import Typography from '@/components/ui/typography';
 import { MODAL_ID } from '@/constants/modal-id-constants';
 import { useDeleteResumeMutation } from '@/features/resume/hooks/use-delete-resume-mutation';
-import Trash from '@/components/icons/trash';
-import { formatDate } from '@/utils/format-date';
+import DraftResumeItem from '@/features/resume/draft-resume-item';
 import type { Resume } from '@prisma/client';
-import DraftResumeItem from './draft-resume-item';
 
 const { DRAFT_RESUME } = MODAL_ID;
 

--- a/src/features/resume/draft-resumes-modal.tsx
+++ b/src/features/resume/draft-resumes-modal.tsx
@@ -40,27 +40,32 @@ const DraftResumesModal = ({ draftResumeList, isError, onLoadDraft, activeResume
           임시 저장된 자소서
         </Typography>
         <Typography color='primary-600' weight='bold' align='center'>
-          작성 완료 시 200 경험치 획득!
+          작성 완료 시 300 경험치 획득!
         </Typography>
       </div>
       {!isError && draftResumeList?.length === 0 ? (
         <Typography>임시 저장된 자기소개서가 없습니다</Typography>
       ) : (
-        draftResumeList?.map((resume) => {
-          return (
-            <div key={resume.id} className='flex flex-col'>
-              <div className='flex justify-between'>
-                <Typography color='gray-500'>{formatDate({ input: resume.createdAt })}</Typography>
-                <button onClick={() => handleDeleteResume(resume.id)}>
-                  <Trash />
+        <ul className='flex flex-col gap-4'>
+          {draftResumeList?.map((resume) => {
+            return (
+              <li key={resume.id} className='flex flex-col'>
+                <div className='flex justify-between'>
+                  <Typography color='gray-500'>{formatDate({ input: resume.createdAt })}</Typography>
+                  <button onClick={() => handleDeleteResume(resume.id)}>
+                    <Trash />
+                  </button>
+                </div>
+                <button
+                  className='text-left font-bold text-cool-gray-900'
+                  onClick={() => handleDraftResumeClick(resume)}
+                >
+                  {resume.title}
                 </button>
-              </div>
-              <button className='text-left font-bold text-cool-gray-900' onClick={() => handleDraftResumeClick(resume)}>
-                {resume.title}
-              </button>
-            </div>
-          );
-        })
+              </li>
+            );
+          })}
+        </ul>
       )}
     </Modal>
   );

--- a/src/features/resume/draft-resumes-modal.tsx
+++ b/src/features/resume/draft-resumes-modal.tsx
@@ -3,11 +3,12 @@
 import { Dispatch, SetStateAction } from 'react';
 import Modal from '@/components/ui/modal';
 import Typography from '@/components/ui/typography';
-import type { Resume } from '@prisma/client';
 import { MODAL_ID } from '@/constants/modal-id-constants';
 import { useDeleteResumeMutation } from '@/features/resume/hooks/use-delete-resume-mutation';
 import Trash from '@/components/icons/trash';
 import { formatDate } from '@/utils/format-date';
+import type { Resume } from '@prisma/client';
+import DraftResumeItem from './draft-resume-item';
 
 const { DRAFT_RESUME } = MODAL_ID;
 
@@ -49,20 +50,11 @@ const DraftResumesModal = ({ draftResumeList, isError, onLoadDraft, activeResume
         <ul className='flex flex-col gap-4'>
           {draftResumeList?.map((resume) => {
             return (
-              <li key={resume.id} className='flex flex-col'>
-                <div className='flex justify-between'>
-                  <Typography color='gray-500'>{formatDate({ input: resume.createdAt })}</Typography>
-                  <button onClick={() => handleDeleteResume(resume.id)}>
-                    <Trash />
-                  </button>
-                </div>
-                <button
-                  className='text-left font-bold text-cool-gray-900'
-                  onClick={() => handleDraftResumeClick(resume)}
-                >
-                  {resume.title}
-                </button>
-              </li>
+              <DraftResumeItem
+                resume={resume}
+                onDeleteClick={handleDeleteResume}
+                onDraftResumeClick={handleDraftResumeClick}
+              />
             );
           })}
         </ul>

--- a/src/features/resume/draft-resumes-modal.tsx
+++ b/src/features/resume/draft-resumes-modal.tsx
@@ -7,6 +7,7 @@ import type { Resume } from '@prisma/client';
 import { MODAL_ID } from '@/constants/modal-id-constants';
 import { useDeleteResumeMutation } from '@/features/resume/hooks/use-delete-resume-mutation';
 import Trash from '@/components/icons/trash';
+import { formatDate } from '@/utils/format-date';
 
 const { DRAFT_RESUME } = MODAL_ID;
 
@@ -33,18 +34,33 @@ const DraftResumesModal = ({ draftResumeList, isError, onLoadDraft, activeResume
   };
 
   return (
-    <Modal modalId={DRAFT_RESUME} className='flex flex-col gap-2'>
+    <Modal modalId={DRAFT_RESUME} className='flex flex-col gap-4'>
+      <div>
+        <Typography as='h2' size='2xl' weight='bold' align='center'>
+          임시 저장된 자소서
+        </Typography>
+        <Typography color='primary-600' weight='bold' align='center'>
+          작성 완료 시 200 경험치 획득!
+        </Typography>
+      </div>
       {!isError && draftResumeList?.length === 0 ? (
         <Typography>임시 저장된 자기소개서가 없습니다</Typography>
       ) : (
-        draftResumeList?.map((resume) => (
-          <div key={resume.id} className='flex justify-between'>
-            <button onClick={() => handleDraftResumeClick(resume)}>{resume.title}</button>
-            <button onClick={() => handleDeleteResume(resume.id)}>
-              <Trash />
-            </button>
-          </div>
-        ))
+        draftResumeList?.map((resume) => {
+          return (
+            <div key={resume.id} className='flex flex-col'>
+              <div className='flex justify-between'>
+                <Typography color='gray-500'>{formatDate({ input: resume.createdAt })}</Typography>
+                <button onClick={() => handleDeleteResume(resume.id)}>
+                  <Trash />
+                </button>
+              </div>
+              <button className='text-left font-bold text-cool-gray-900' onClick={() => handleDraftResumeClick(resume)}>
+                {resume.title}
+              </button>
+            </div>
+          );
+        })
       )}
     </Modal>
   );

--- a/src/features/resume/question-answer-field.tsx
+++ b/src/features/resume/question-answer-field.tsx
@@ -19,8 +19,8 @@ const QuestionAnswerField = ({ field, onChange, onDelete }: Props) => {
           <Typography weight='normal' color='primary-600'>
             질문 1
           </Typography>
-          <button type='button' onClick={() => onDelete(id)} className='flex gap-5'>
-            <span className='font-semibold text-cool-gray-500'>질문 삭제</span> <Trash />
+          <button type='button' onClick={() => onDelete(id)}>
+            <Trash />
           </button>
         </div>
         <input

--- a/src/features/resume/resume-form-action-button.tsx
+++ b/src/features/resume/resume-form-action-button.tsx
@@ -1,0 +1,34 @@
+import Button from '@/components/ui/button';
+import Typography from '@/components/ui/typography';
+import { Resume } from '@prisma/client';
+
+type Props = {
+  resume?: Resume;
+  draftResumeList?: Resume[];
+  autoSaveStatus: string;
+  onClick: () => void;
+};
+
+const ResumeFormActionButton = ({ resume, draftResumeList, autoSaveStatus, onClick }: Props) => {
+  return (
+    <div className='flex justify-between'>
+      {resume ? (
+        <Button variant='outline' color='dark' size='large' type='submit'>
+          수정 완료
+        </Button>
+      ) : (
+        <div className='flex gap-8'>
+          <Button variant='outline' color='dark' size='large' type='button' onClick={onClick}>
+            임시 저장된 글 | {draftResumeList?.length ?? 0}
+          </Button>
+          <Button variant='outline' color='dark' size='large' type='submit'>
+            작성 완료
+          </Button>
+        </div>
+      )}
+      <Typography color='gray-500'>{autoSaveStatus}</Typography>
+    </div>
+  );
+};
+
+export default ResumeFormActionButton;

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -79,12 +79,14 @@ const ResumeForm = ({ resume }: Props) => {
           질문 추가 +
         </button>
       </div>
+
       {fieldList.map((field) => {
         return (
           <QuestionAnswerField key={field.id} field={field} onChange={handleFieldChange} onDelete={handleDeleteField} />
         );
       })}
 
+      {/** 버튼 */}
       <div className='flex justify-between'>
         {resume ? (
           <Button variant='outline' color='dark' size='large' type='submit'>
@@ -103,6 +105,7 @@ const ResumeForm = ({ resume }: Props) => {
         <Typography color='gray-500'>{autoSaveStatus}</Typography>
       </div>
 
+      {/** 모달 */}
       {isModalOpen && (
         <DraftResumesModal
           draftResumeList={draftResumeList}

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -11,6 +11,7 @@ import QuestionAnswerField from '@/features/resume/question-answer-field';
 import DraftResumesModal from '@/features/resume/draft-resumes-modal';
 import type { Field, ResumeData } from '@/types/resume';
 import type { Resume } from '@prisma/client';
+import ResumeFormActionButton from './resume-form-action-button';
 
 const { DRAFT_RESUME } = MODAL_ID;
 
@@ -87,23 +88,12 @@ const ResumeForm = ({ resume }: Props) => {
       })}
 
       {/** 버튼 */}
-      <div className='flex justify-between'>
-        {resume ? (
-          <Button variant='outline' color='dark' size='large' type='submit'>
-            수정 완료
-          </Button>
-        ) : (
-          <div className='flex gap-8'>
-            <Button variant='outline' color='dark' size='large' type='button' onClick={handleDraftResumeListClick}>
-              임시 저장된 글 | {draftResumeList?.length ?? 0}
-            </Button>
-            <Button variant='outline' color='dark' size='large' type='submit'>
-              작성 완료
-            </Button>
-          </div>
-        )}
-        <Typography color='gray-500'>{autoSaveStatus}</Typography>
-      </div>
+      <ResumeFormActionButton
+        resume={resume}
+        draftResumeList={draftResumeList}
+        autoSaveStatus={autoSaveStatus}
+        onClick={handleDraftResumeListClick}
+      />
 
       {/** 모달 */}
       {isModalOpen && (


### PR DESCRIPTION
## 💡 관련이슈
- #147 

## 🍀 작업 요약
- 공통 모달 컴포넌트의 widh는 434px, padding은 32px로 고정하였습니다
=> 따로 내부에서 패딩값을 주지 않으셔도 됩니다.
=> 높이는 자동으로 늘어납니다. 

모달 사용하고 계신 분들은 tailwind 부분을 수정하셔야될 것 같습니다!

## 💬 리뷰 요구 사항
모달 스타일이 잘 적용됐는지 확인 부탁드립니다.

## 💛 미리보기
<img width="1011" alt="스크린샷 2025-04-18 오후 2 28 06" src="https://github.com/user-attachments/assets/317e63c0-86b6-4149-b4c9-0018730c32f9" />


### ✔️ 이슈 닫기
Closes #147 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 닫기(“X”) 아이콘 컴포넌트가 추가되었습니다.
  - 이력서 작성 폼에 관련된 동작 버튼 컴포넌트가 새로 도입되어, 임시 저장 글 보기 및 제출 버튼이 통합되었습니다.
  - 임시 저장 자소서 항목을 개별 컴포넌트로 분리하여 목록에서 관리할 수 있게 되었습니다.
  - 임시 저장 자소서 삭제 시 확인 대화상자가 추가되어 실수 삭제를 방지합니다.
  - 페이지 이탈 방지 기능이 녹음 중 상태에 적용되어 작업 중 데이터 손실을 줄입니다.

- **Style**
  - 모달의 최대 너비가 600px에서 434px로 축소되고, 최대 높이 600px에 스크롤이 추가되었습니다.
  - 모서리 둥글기가 더 커졌으며, 모달 닫기 버튼이 텍스트에서 아이콘으로 변경되었습니다.
  - 임시 저장 자소서 모달에 제목과 부제목이 추가되고, 각 항목의 레이아웃이 개선되었습니다.
  - 전체적으로 모달 및 자소서 목록의 디자인이 향상되었습니다.
  - 전체 레이아웃의 클래스 구조가 간소화되고, 폰트 스타일이 본문에 적용되었습니다.
  - 삭제 버튼 내 “질문 삭제” 텍스트가 제거되어 아이콘만 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->