### PR TITLE
Style/#161 user meta form UI

### DIFF
--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -49,7 +49,7 @@ const Modal = ({ portalRoot, modalId, children, className }: Props) => {
       <div className='fixed inset-0 bg-black opacity-70' />
       <div
         ref={modalContentRef}
-        className='relative max-h-[600px] w-full max-w-[434px] flex-col overflow-scroll rounded-3xl bg-white p-8 scrollbar-hide'
+        className='relative max-h-[650px] w-full max-w-[434px] flex-col overflow-scroll rounded-3xl bg-white p-8 scrollbar-hide'
       >
         <button onClick={() => toggleModal(modalId)} className='absolute right-4 top-4'>
           <Close />

--- a/src/constants/character-constants.ts
+++ b/src/constants/character-constants.ts
@@ -15,7 +15,7 @@
 type CharacterDescription = Record<number, { name: string }>;
 type CharacterInfo = Record<string, CharacterDescription>;
 
-export const LEVEL_EXP = [0, 1500, 3000, 6000, 10000, 17000];
+export const LEVEL_EXP = [0, 1500, 3000, 6000, 10000, 17000] as const;
 
 export const CHARACTER_INFORMATION: CharacterInfo = {
   clay: {

--- a/src/features/user-meta-data/select-box.tsx
+++ b/src/features/user-meta-data/select-box.tsx
@@ -15,7 +15,11 @@ const SelectBox = ({ options, selected = DEFAULT, onSelect }: Props) => {
   };
 
   return (
-    <select value={selected} onChange={handleSelect} className='rounded-lg border border-cool-gray-200 px-4 py-2'>
+    <select
+      value={selected}
+      onChange={handleSelect}
+      className='my-1 rounded-[8px] border border-cool-gray-200 px-4 py-2'
+    >
       <option value={DEFAULT}>선택</option>
       {options.map((option) => (
         <option key={`option_${option.name}`} value={option.value}>

--- a/src/features/user-meta-data/select-box.tsx
+++ b/src/features/user-meta-data/select-box.tsx
@@ -6,7 +6,7 @@ import type { SelectBoxType } from '@/types/select-box';
 type Props = {
   options: SelectBoxType[];
   selected: string;
-  onSelect: (value: SelectBoxType['name']) => void; //@TODO: 추후 type 'value'로 수정
+  onSelect: (value: SelectBoxType['value']) => void; //@TODO: 추후 type 'value'로 수정
 };
 
 const SelectBox = ({ options, selected = DEFAULT, onSelect }: Props) => {

--- a/src/features/user-meta-data/single-select-field.tsx
+++ b/src/features/user-meta-data/single-select-field.tsx
@@ -15,10 +15,10 @@ type Props = {
 
 const SingleSelectField = ({ label, options, value, fieldKey, onSelect, error }: Props) => {
   return (
-    <div className='mb-4 flex h-14 flex-col justify-center'>
-      <label>{label}</label>
+    <div className='mb-1/2 flex min-h-14 flex-col justify-center'>
+      <label className='font-bold'>{label}</label>
       <SelectBox options={options} selected={value} onSelect={(selected) => onSelect(fieldKey, selected)} />
-      <p className='h-4 text-right text-red-500'>{error}</p>
+      <p className='h-5 text-xs text-primary-orange-600'>{error}</p>
     </div>
   );
 };

--- a/src/features/user-meta-data/single-select-field.tsx
+++ b/src/features/user-meta-data/single-select-field.tsx
@@ -18,7 +18,7 @@ const SingleSelectField = ({ label, options, value, fieldKey, onSelect, error }:
     <div className='mb-1/2 flex min-h-14 flex-col justify-center'>
       <label className='font-bold'>{label}</label>
       <SelectBox options={options} selected={value} onSelect={(selected) => onSelect(fieldKey, selected)} />
-      <p className='h-5 text-xs text-primary-orange-600'>{error}</p>
+      <p className='h-5 text-sm text-primary-orange-600'>{error}</p>
     </div>
   );
 };

--- a/src/features/user-meta-data/user-meta-data-form.tsx
+++ b/src/features/user-meta-data/user-meta-data-form.tsx
@@ -26,11 +26,9 @@ const UserMetaDataForm = () => {
   return (
     <div>
       {isFirstTime && (
-        <span className='text-md mb-4 block text-center font-light text-primary-orange-600'>
-          작성 완료 시 500 경험치 획득!
-        </span>
+        <span className='mb-4 block text-center font-bold text-primary-orange-600'>작성 완료 시 500 경험치 획득!</span>
       )}
-      <form onSubmit={handleSubmit(handleOnSubmit)} className='mx-auto w-2/3'>
+      <form onSubmit={handleSubmit(handleOnSubmit)}>
         <SingleSelectField
           label='*경력'
           options={typeData}
@@ -64,13 +62,18 @@ const UserMetaDataForm = () => {
           error={errors[LOCATION_NAME]?.message}
         />
 
-        <div className='mb-4 flex h-14 flex-col justify-center'>
-          <label>기타 커리어</label>
-          <input className='rounded-lg border border-cool-gray-200 px-4 py-2' id={ETC} type='text' {...register(ETC)} />
+        <div className='mb-4 flex min-h-14 flex-col justify-center'>
+          <label className='mb-2 text-cool-gray-300'>ex. 수상이력, 자격증 등</label>
+          <input
+            className='rounded-[8px] border border-cool-gray-200 px-4 py-2'
+            id={ETC}
+            type='text'
+            {...register(ETC)}
+          />
         </div>
         <div className='text-center'>
           <Button variant='outline' color='dark' type='submit'>
-            설정을 완료헀어요!
+            <span className='font-bold'>설정을 완료헀어요!</span>
           </Button>
         </div>
       </form>

--- a/src/features/user-meta-data/user-meta-data-form.tsx
+++ b/src/features/user-meta-data/user-meta-data-form.tsx
@@ -7,8 +7,12 @@ import useRegionsQuery from '@/features/user-meta-data/hooks/use-regions-query';
 import SingleSelectField from '@/features/user-meta-data/single-select-field';
 import { useMetaDataForm } from '@/features/user-meta-data/hooks/use-meta-data-form';
 import { USER_META_DATA_KEY } from '@/constants/user-meta-data-constants';
+import LoadingSpinner from '@/components/ui/loading-spinner';
+import { CHARACTER_HISTORY, CHARACTER_HISTORY_KEY } from '@/constants/character-constants';
 
 const { EXPERIENCE_NAME, REQUIRED_EDUCATION_NAME, JOB_MID_CODE_NAME, LOCATION_NAME, ETC } = USER_META_DATA_KEY;
+const { FILL_OUT_META_DATA } = CHARACTER_HISTORY_KEY;
+const EXP = CHARACTER_HISTORY[FILL_OUT_META_DATA].amount;
 
 const UserMetaDataForm = () => {
   const { data } = useSession();
@@ -21,12 +25,14 @@ const UserMetaDataForm = () => {
 
   const { data: regions = [], isPending } = useRegionsQuery();
 
-  if (isPending || isMetaDataPending) return <div>로딩 중..</div>;
+  if (isPending || isMetaDataPending) return <LoadingSpinner />;
 
   return (
     <div>
       {isFirstTime && (
-        <span className='mb-4 block text-center font-bold text-primary-orange-600'>작성 완료 시 500 경험치 획득!</span>
+        <span className='mb-4 block text-center font-bold text-primary-orange-600'>
+          작성 완료 시 {EXP} 경험치 획득!
+        </span>
       )}
       <form onSubmit={handleSubmit(handleOnSubmit)}>
         <SingleSelectField
@@ -65,7 +71,7 @@ const UserMetaDataForm = () => {
         <div className='mb-4 flex min-h-14 flex-col justify-center'>
           <label className='mb-2 text-cool-gray-300'>ex. 수상이력, 자격증 등</label>
           <input
-            className='rounded-[8px] border border-cool-gray-200 px-4 py-2'
+            className='active: rounded-[8px] border border-cool-gray-200 px-4 py-2'
             id={ETC}
             type='text'
             {...register(ETC)}

--- a/src/features/user-meta-data/user-meta-data-modal.tsx
+++ b/src/features/user-meta-data/user-meta-data-modal.tsx
@@ -4,7 +4,7 @@ import UserMetaDataForm from '@/features/user-meta-data/user-meta-data-form';
 const UserMetaDataModal = () => {
   return (
     <section>
-      <Typography as='h1' size='2xl' align='center' weight='bold'>
+      <Typography as='h2' size='2xl' align='center' weight='bold'>
         주요 이력 작성하기
       </Typography>
       <UserMetaDataForm />

--- a/src/features/user-meta-data/user-meta-data-modal.tsx
+++ b/src/features/user-meta-data/user-meta-data-modal.tsx
@@ -4,7 +4,7 @@ import UserMetaDataForm from '@/features/user-meta-data/user-meta-data-form';
 const UserMetaDataModal = () => {
   return (
     <section>
-      <Typography as='h1' size='lg' align='center'>
+      <Typography as='h1' size='2xl' align='center' weight='bold'>
         주요 이력 작성하기
       </Typography>
       <UserMetaDataForm />


### PR DESCRIPTION
## 💡 관련이슈

- #161 

## 🍀 작업 요약

- 유저 정보 폼 UI 수정 건 반영하였습니다!

## 💬 리뷰 요구 사항

- 잘 반영되었는지 확인해 주세요!

## 💛 미리보기

<img width="485" alt="image" src="https://github.com/user-attachments/assets/19776ddd-ebe1-4339-abd1-3c6270094dbb" />

<img width="479" alt="image" src="https://github.com/user-attachments/assets/839d7cda-d8ff-438a-b2e0-1f26d5430160" />

<img width="468" alt="image" src="https://github.com/user-attachments/assets/276950a5-6b7a-43fa-a779-5bd952ff5524" />

<img width="490" alt="image" src="https://github.com/user-attachments/assets/d553bc68-190a-40bb-badf-9847c6895ae2" />


### ✔️ 이슈 닫기

Closes #161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
    - 모달 창의 최대 높이가 600px에서 650px로 증가했습니다.
    - 단일 선택 필드, 선택 박스, 사용자 메타데이터 폼, 모달 등에서 폰트 굵기, 색상, 여백, 테두리 반경 등 UI 스타일이 개선되었습니다.
    - 사용자 메타데이터 폼의 "기타 커리어" 입력란 예시 문구와 스타일이 변경되었습니다.
    - 메타데이터 모달의 제목 크기와 굵기가 더 강조되었습니다.

- **New Features**
    - 데이터 로딩 및 제출 시 기존 텍스트 대신 로딩 스피너가 표시됩니다.
    - 첫 방문자 안내 메시지의 경험치가 상수에서 동적으로 표시됩니다.

- **Refactor**
    - 선택 박스의 onSelect 콜백 파라미터 타입이 더 명확하게 변경되었습니다.
    - 경험치 상수 배열이 불변으로 처리되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->