### PR TITLE
Bugfix/#160 interview history feedback status

### DIFF
--- a/src/app/(with-nav)/(with-header)/my-page/page.tsx
+++ b/src/app/(with-nav)/(with-header)/my-page/page.tsx
@@ -9,7 +9,7 @@ const MyPage = async () => {
   if (!session) return null;
 
   return (
-    <article className='flex w-full items-center gap-2 px-12 py-8'>
+    <article className='flex w-full items-center justify-between gap-2 px-12 py-8'>
       <ViewingField session={session} />
       <TabsField userId={session?.user.id} />
     </article>

--- a/src/app/api/interview-history/[userId]/route.ts
+++ b/src/app/api/interview-history/[userId]/route.ts
@@ -53,7 +53,7 @@ export const GET = async (request: NextRequest, { params }: Props) => {
     });
 
     const totalCount = await prisma.interviewHistory.count({
-      where: { userId },
+      where: { userId, status: COMPLETED_INTERVIEW_CODE },
     });
     const nextPage = pageNumber * limitNumber < totalCount ? pageNumber + 1 : null;
     if (!histories) return NextResponse.json({ data: [], nextPage }, { status: 200 });

--- a/src/app/api/interview-history/[userId]/route.ts
+++ b/src/app/api/interview-history/[userId]/route.ts
@@ -22,6 +22,9 @@ const {
 const {
   API: { GET_ERROR },
 } = INTERVIEW_HISTORY;
+
+const COMPLETED_INTERVIEW_CODE = 1;
+
 export const GET = async (request: NextRequest, { params }: Props) => {
   try {
     const token = await getToken({ req: request, secret: NEXTAUTH_SECRET });
@@ -40,7 +43,7 @@ export const GET = async (request: NextRequest, { params }: Props) => {
     }
 
     const histories = await prisma.interviewHistory.findMany({
-      where: { userId: userId },
+      where: { userId: userId, status: COMPLETED_INTERVIEW_CODE },
       orderBy: { createdAt: 'desc' },
       include: {
         resume: true,
@@ -53,16 +56,15 @@ export const GET = async (request: NextRequest, { params }: Props) => {
       where: { userId },
     });
     const nextPage = pageNumber * limitNumber < totalCount ? pageNumber + 1 : null;
-
     if (!histories) return NextResponse.json({ data: [], nextPage }, { status: 200 });
     const parsedHistories = histories.map((history) => {
-      const resumeTitle = history?.resume?.title ?? null;
-
+      const resumeTitle = history.resume.title ?? null;
       return {
-        ...history,
-        resumeTitle: resumeTitle,
-        isFeedbackCompleted: history.feedback ?? false, //@TODO:어떤 형태로 올지 모르겠음.. feedback 있으면 true,없음 false
-        createdDate: formatDate({ input: history.createdAt }),
+        id: history.id,
+        title: resumeTitle,
+        interviewer: history.interviewType,
+        isFeedbackCompleted: !!history.feedback,
+        createdAt: formatDate({ input: history.createdAt }),
       };
     });
     return NextResponse.json({ data: parsedHistories, nextPage }, { status: 200 });

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -1,3 +1,5 @@
+import clsx from 'clsx';
+
 type Props = {
   size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 };
@@ -14,7 +16,12 @@ const spinnerSize = {
 const LoadingSpinner = ({ size = 'md' }: Props) => {
   return (
     <div
-      className={`role="status" aria-label="로딩 중" animate-spin rounded-full ${spinnerSize[size]} border-4 border-b-secondary-amber border-l-secondary-yellow border-r-secondary-amber border-t-secondary-yellow opacity-80`}
+      role='status'
+      aria-label='로딩 중'
+      className={clsx(
+        'animate-spin rounded-full border-4 border-b-secondary-amber border-l-secondary-yellow border-r-secondary-amber border-t-secondary-yellow opacity-80',
+        spinnerSize[size]
+      )}
     />
   );
 };

--- a/src/features/interview-history/api/client-services.ts
+++ b/src/features/interview-history/api/client-services.ts
@@ -14,11 +14,14 @@ type Params = {
   limit: number;
 };
 
-type Return = InterviewHistory & {
-  resumeTitle: Resume['title'];
+type Return = {
+  id: InterviewHistory['id'];
+  interviewer: InterviewHistory['interviewType'];
+  title: Resume['title'];
   isFeedbackCompleted: boolean;
-  createdDate: string;
+  createdAt: string;
 };
+
 export const getInterviewHistories = async ({
   userId,
   pageParam,

--- a/src/features/interview-history/interview-history-list.tsx
+++ b/src/features/interview-history/interview-history-list.tsx
@@ -1,14 +1,15 @@
 'use client';
-import { INTERVIEW_TYPE, INTERVIEW_TYPE_KR } from '@/constants/interview-constants';
-import { TABS } from '@/constants/my-page-constants';
-import clsx from 'clsx';
-import ErrorComponent from '@/components/common/error-component';
-import EmptyList from '@/features/my-page/empty-list';
-import { useInterviewHistoryInfiniteQuery } from '@/features/interview-history/hook/use-interview-history-infinite-query';
-import { useInfiniteScroll } from '@/hooks/customs/use-infinite-scroll';
-import type { InterviewHistory, User } from '@prisma/client';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import type { InterviewHistory, User } from '@prisma/client';
+import clsx from 'clsx';
+import { useInterviewHistoryInfiniteQuery } from '@/features/interview-history/hook/use-interview-history-infinite-query';
+import EmptyList from '@/features/my-page/empty-list';
+import { useInfiniteScroll } from '@/hooks/customs/use-infinite-scroll';
+import ErrorComponent from '@/components/common/error-component';
+import LoadingSpinner from '@/components/ui/loading-spinner';
+import { INTERVIEW_TYPE, INTERVIEW_TYPE_KR } from '@/constants/interview-constants';
+import { TABS } from '@/constants/my-page-constants';
 
 const { CALM } = INTERVIEW_TYPE;
 const { CALM_KR, PRESSURE_KR } = INTERVIEW_TYPE_KR;
@@ -32,7 +33,7 @@ const InterviewHistoryList = () => {
     hasNextPage,
   });
 
-  if (isPending) return <div className='text-center'>로딩 중..</div>;
+  if (isPending) return <LoadingSpinner />;
   if (isError) return <ErrorComponent />;
 
   const handleGetDetailList = (historyId: InterviewHistory['id']) => {
@@ -57,8 +58,8 @@ const InterviewHistoryList = () => {
               aria-disabled={history.isFeedbackCompleted}
             >
               <div>
-                <span className='text-md block font-bold text-cool-gray-900'>{history.resumeTitle}</span>
-                <span className='text-sm'>{getInterviewer(history.interviewType)}</span>
+                <span className='text-md block font-bold text-cool-gray-900'>{history.title}</span>
+                <span className='text-sm'>{getInterviewer(history.interviewer)}</span>
               </div>
               <div>
                 <span
@@ -69,7 +70,7 @@ const InterviewHistoryList = () => {
                 >
                   {history.isFeedbackCompleted ? '평가 완료' : '평가 중'}
                 </span>
-                <span className='text-sm'>{history.createdDate}</span>
+                <span className='text-sm'>{history.createdAt}</span>
               </div>
             </li>
           ))}

--- a/src/features/interview-history/interview-history-list.tsx
+++ b/src/features/interview-history/interview-history-list.tsx
@@ -33,7 +33,12 @@ const InterviewHistoryList = () => {
     hasNextPage,
   });
 
-  if (isPending) return <LoadingSpinner />;
+  if (isPending)
+    return (
+      <div className='flex h-full items-center justify-center'>
+        <LoadingSpinner />
+      </div>
+    );
   if (isError) return <ErrorComponent />;
 
   const handleGetDetailList = (historyId: InterviewHistory['id']) => {

--- a/src/features/my-page/tab-buttons.tsx
+++ b/src/features/my-page/tab-buttons.tsx
@@ -47,7 +47,7 @@ const TabButtons = ({ tabCounts }: Props) => {
           key={`tab_${tab.id}`}
           className={clsx(
             'text-md w-1/3 px-4 py-[14px] text-center font-bold text-cool-gray-900',
-            targetTab === tab.id && 'border-b-2 border-b-cool-gray-900'
+            targetTab === tab.id && 'border-b-2 border-b-primary-orange-600'
           )}
         >
           <button

--- a/src/features/my-page/tab-buttons.tsx
+++ b/src/features/my-page/tab-buttons.tsx
@@ -1,9 +1,10 @@
 'use client';
 import clsx from 'clsx';
-import { TABS } from '@/constants/my-page-constants';
-import { useTabStore } from '@/store/use-tab-store';
-import type { Tabs } from '@/types/tab-type';
 import { useEffect } from 'react';
+import { useTabStore } from '@/store/use-tab-store';
+import Badge from '@/components/ui/badge';
+import { TABS } from '@/constants/my-page-constants';
+import type { Tabs } from '@/types/tab-type';
 
 const { BOOKMARK, RESUME, HISTORY } = TABS;
 
@@ -40,13 +41,13 @@ const TabButtons = ({ tabCounts }: Props) => {
     return () => resetTab();
   }, []);
   return (
-    <ul className='flex h-12 items-center justify-evenly rounded-t-xl bg-cool-gray-100'>
+    <ul className='flex h-12 items-center justify-evenly bg-cool-gray-100'>
       {tabs.map((tab) => (
         <li
           key={`tab_${tab.id}`}
           className={clsx(
-            'text-md w-1/3 rounded-t-xl px-4 py-[14px] text-center font-bold text-cool-gray-900',
-            targetTab === tab.id && 'bg-cool-gray-300'
+            'text-md w-1/3 px-4 py-[14px] text-center font-bold text-cool-gray-900',
+            targetTab === tab.id && 'border-b-2 border-b-cool-gray-900'
           )}
         >
           <button
@@ -55,9 +56,12 @@ const TabButtons = ({ tabCounts }: Props) => {
           >
             {tab.title}
             {tabCounts[tab.id] !== 0 && (
-              <span className='mx-1 rounded-xl bg-cool-gray-900 px-[10px] py-[2px] text-xs text-cool-gray-50'>
-                {tabCounts[tab.id]}개
-              </span>
+              <Badge mx={1} size='small' color='dark'>
+                {tabCounts[tab.id]}
+              </Badge>
+              // <span className='mx-1 rounded-xl bg-cool-gray-900 px-[10px] py-[2px] text-xs text-cool-gray-50'>
+              //   {tabCounts[tab.id]}개
+              // </span>
             )}
           </button>
         </li>

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -1,8 +1,8 @@
 import { prisma } from '@/lib/prisma';
+import type { User } from '@prisma/client';
 import ListByTab from '@/features/my-page/list-by-tab';
 import TabButtons from '@/features/my-page/tab-buttons';
 
-import type { User } from '@prisma/client';
 type Props = {
   userId: User['id'];
 };
@@ -27,7 +27,7 @@ const TabsField = async ({ userId }: Props) => {
   };
 
   return (
-    <section className='h-[80dvh] w-1/2 rounded-t-xl border'>
+    <section className='h-[80dvh] w-1/2 rounded-t-[8px] border'>
       <TabButtons tabCounts={tabCounts} />
       <div className='p-8'>
         <ListByTab />

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -27,7 +27,7 @@ const TabsField = async ({ userId }: Props) => {
   };
 
   return (
-    <section className='h-[80dvh] w-1/2 rounded-t-[8px] border'>
+    <section className='h-[80dvh] w-1/2 max-w-[628px] rounded-t-[8px] border bg-cool-gray-10'>
       <TabButtons tabCounts={tabCounts} />
       <div className='p-8'>
         <ListByTab />

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -27,9 +27,9 @@ const TabsField = async ({ userId }: Props) => {
   };
 
   return (
-    <section className='h-[80dvh] w-1/2 max-w-[628px] rounded-t-[8px] border bg-cool-gray-10'>
+    <section className='h-[80dvh] max-h-[643px] w-1/2 max-w-[634px] rounded-t-[8px] border bg-cool-gray-10'>
       <TabButtons tabCounts={tabCounts} />
-      <div className='p-8'>
+      <div className='h-full p-8'>
         <ListByTab />
       </div>
     </section>


### PR DESCRIPTION
## 💡 관련이슈

#160 

## 🍀 작업 요약

- 마이페이지 > 인터뷰 기록 리스트에서 `평가 상태`가 제대로 반영되지 않는 이슈 해결
- 기존 방식 : 해당 사용자의 모든 인터뷰 기록을 가져와 feedback이 없으면 평가 중, 있으면 평가 완료로 처리
- 문제 원인 : 인터뷰를 완료하지 않고 페이지를 벗어나도 history에는 기록이 쌓이기 때문에 feedback은 없는 상태로 저장 
                 -> feedback이 없어 `평가 중`으로 판단됨. 하지만 인터뷰 페이지를 벗어났기 때문에 영원히 평가 중으로 남음
- 해결 방법 : DB에 면접 완료를 체크하는 column을 하나 추가하고 사용자가 마지막 면접 질문에 대답한 뒤 '면접 완료' 버튼 클릭 시
                   DB에 면접 완료 상태를 업데이트시킴


## 💬 리뷰 요구 사항

- 지금 AI 면접 쪽 기능 리팩토링 중이라 면접을 볼 수가 없어서 DB에 저장된 데이터로만 테스트를 진행했습니다.
- @minchulpack 민조님 리팩토링 완료되면 알려주세요! 테스트 진행하겠습니다~
- 다른 분들도 인터뷰 가능해지면 테스트 한 번씩 진행 부탁드릴게요 😊

## 💛 미리보기
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/d83ab200-199b-4345-a718-884e8f80c99e" />

@ImJaeOne 재원님 근데 meta data 없을 때 overlay가 있었던 거 같은데 일부러 없애신걸까요?🤔

### ✔️ 이슈 닫기

Closes #160 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
	- 마이페이지 및 탭 버튼, 인터뷰 내역 리스트 등의 레이아웃과 버튼, 뱃지, 컨테이너 스타일이 개선되었습니다.
	- 인터뷰 내역 리스트의 로딩 표시가 스피너로 변경되었습니다.
	- 마이페이지 내 아티클 정렬이 자식 요소 간 공간 배분으로 조정되었습니다.
- **버그 수정**
	- 인터뷰 내역 리스트에서 보여지는 필드명이 일부 변경 및 정정되었습니다.
- **기능 개선**
	- 인터뷰 내역 조회 시 완료된 인터뷰만 표시되도록 변경되었습니다.
	- 인터뷰 내역 리스트의 정보 표현 방식이 보다 명확하게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->