### PR TITLE
Feature/#182 redirect after login

### DIFF
--- a/src/features/character/my-character.tsx
+++ b/src/features/character/my-character.tsx
@@ -42,7 +42,7 @@ const MyCharacter = ({ session, characterData = defaultCharacter, overlayText, r
                 <Typography weight='black' size='xl' color='primary-600'>
                   LV {level}
                 </Typography>
-                <div className='line-clamp-1 w-[72px]'>
+                <div className='line-clamp-1 min-w-56'>
                   <Typography weight='bold'>{session?.user.name}님</Typography>
                 </div>
               </div>

--- a/src/features/sign/hooks/use-sign-in-result.ts
+++ b/src/features/sign/hooks/use-sign-in-result.ts
@@ -7,6 +7,7 @@ import { PATH } from '@/constants/path-constant';
 
 const { SIGN_IN_FAILED, SOCIAL_SIGN_IN_EXIST_ERROR, SOCIAL_SIGN_IN_FAILED } = AUTH_MESSAGE.RESULT;
 const { SIGN_IN } = PATH.AUTH;
+const { ON_BOARDING } = PATH;
 
 const NEXT_AUTH_STATUS = {
   OAUTH_ACCOUNT_NOT_LINKED: 'OAuthAccountNotLinked',
@@ -17,10 +18,12 @@ export const useSignInResult = () => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const error = searchParams.get('error');
+  const prevUrl = searchParams.get('prevUrl');
+  const callbackUrl = searchParams.get('callbackUrl');
+  const redirectTo = prevUrl || callbackUrl || ON_BOARDING;
 
   useEffect(() => {
     if (!error) return;
-
     if (error === NEXT_AUTH_STATUS.OAUTH_ACCOUNT_NOT_LINKED) {
       alert(SOCIAL_SIGN_IN_EXIST_ERROR);
     } else if (error === NEXT_AUTH_STATUS.CREDENTIAL_SIGN_IN) {
@@ -28,6 +31,6 @@ export const useSignInResult = () => {
     } else {
       alert(SOCIAL_SIGN_IN_FAILED);
     }
-    router.replace(SIGN_IN);
+    router.replace(`${SIGN_IN}?prevUrl=${redirectTo}`);
   }, [error]);
 };

--- a/src/features/sign/sign-in-auth-form.tsx
+++ b/src/features/sign/sign-in-auth-form.tsx
@@ -10,6 +10,7 @@ import { schema, SignInFormData } from '@/features/sign/data/sign-in-schema';
 import Image from 'next/image';
 import { useSignInResult } from './hooks/use-sign-in-result';
 import Typography from '@/components/ui/typography';
+import { useSearchParams } from 'next/navigation';
 
 const { ON_BOARDING } = PATH;
 
@@ -24,12 +25,16 @@ const SignInAuthForm = () => {
     defaultValues: { email: '', password: '' } as SignInFormData,
   });
 
+  const searchParams = useSearchParams();
+  const prevUrl = searchParams.get('prevUrl');
+  const redirectToUrl = prevUrl || ON_BOARDING;
+
   useSignInResult();
 
   const onSubmit = async (data: SignInFormData) => {
     await signIn('credentials', {
       ...data,
-      callbackUrl: ON_BOARDING,
+      callbackUrl: redirectToUrl,
     });
   };
 
@@ -61,14 +66,14 @@ const SignInAuthForm = () => {
       <div className='mt-2 flex flex-col gap-2 text-center'>
         <>
           <button
-            onClick={() => signIn('google', { callbackUrl: ON_BOARDING })}
+            onClick={() => signIn('google', { callbackUrl: redirectToUrl })}
             className='flex w-full items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm'
           >
             <Image src='/assets/google_icon.png' alt='구글 로그인' width={14} height={14} />
             구글 계정으로 로그인
           </button>
           <button
-            onClick={() => signIn('naver', { callbackUrl: ON_BOARDING })}
+            onClick={() => signIn('naver', { callbackUrl: redirectToUrl })}
             className='flex w-full items-center justify-center gap-2 rounded-md bg-[#03C75A] px-4 py-2 text-sm font-bold text-white shadow-sm'
           >
             <Image src='/assets/naver_icon.png' alt='네이버 로그인' width={24} height={24} />

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,40 +16,16 @@ export const middleware = async (request: NextRequest) => {
   const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
   const pathname = request.nextUrl.pathname;
 
-  // next-auth에서는 token이 만료되었는지에 대한 정보를 주지 않음
-  // 따라서 이 사용자가 토큰이 없는 이유가 로그인을 안 해서인지, 토큰이 만료되어서인지 확인 불가
-  // 일단 토큰이 없으면 로그인 페이지로 이동을 하는데,
-  // 만약 로그인 후 활동을 하고 있던 사용자라면
-  // 서버와 통신을 시도할 때는 token이 없어서 서버에서 401 오류를 반환해 주기 때문에 그걸 기반으로 토큰이 만료되었다는 alert를 띄워주고
-  // 사용자가 왜 로그인 페이지로 이동하는지 이유를 알 수 있지만
-  // 서버와 통신이 아닌 auth page로 이동을 하려는 사용자는 이유도 모르고 갑자기 로그인 페이지로 이동함
-  // 왜냐하면 페이지 이동에서는 alert를 띄울 수 없음 -> 우리도 토큰 만료에 의한 이동인지, 비회원이라 이동인지 알 수 없기 때문!
-  // 뾰족한 방법이 없는 관계로 일단 로그인 페이지로 이동시키는 것으로 처리해둠.
-  // unauthorized=true를 넣은 이유 : 토큰이 만료된 상태에서 로그인 페이지로 이동
-  //  -> '토큰'이 만료되었을 뿐 '세션'은 그대로여서 로그인한 상태로 인식
-  // 따라서 queryParams로 토큰 만료되어서 이동한 로그인 페이지임을 알림
-  //   NextResponse.redirect(new URL(`${SIGN_IN}?${UNAUTH}=true`, request.url));
-
-  // if (token && isSignInPage) {
-  //   // 로그인한 사용자가 /sign-in에 접근하는 경우 리디렉트
-  //   return NextResponse.redirect(new URL(ON_BOARDING, request.url));
-  // }
-
-  if (!token && [MY_PAGE, RESUME.ROOT, '/character', JOB, INTERVIEW.START].some((path) => pathname.startsWith(path))) {
-    return NextResponse.redirect(new URL(`${SIGN_IN}?${UNAUTH}=true`, request.url));
+  if (!token && [MY_PAGE, RESUME.ROOT, JOB, INTERVIEW.START].some((path) => pathname.startsWith(path))) {
+    const signInUrl = new URL(SIGN_IN, request.url);
+    signInUrl.searchParams.set(UNAUTH, 'true');
+    signInUrl.searchParams.set('prevUrl', pathname);
+    return NextResponse.redirect(signInUrl);
   }
 
   return NextResponse.next();
 };
 
 export const config = {
-  matcher: [
-    '/my-page',
-    '/resume/:path*',
-    '/character',
-    '/job',
-    '/auth/sign-in',
-    '/interview/start',
-    '/interview/live/:path*',
-  ],
+  matcher: ['/my-page', '/resume/:path*', '/job', '/auth/sign-in', '/interview/start', '/interview/live/:path*'],
 };

--- a/src/utils/auth-option.ts
+++ b/src/utils/auth-option.ts
@@ -13,9 +13,7 @@ const { JSON_HEADER } = API_HEADER;
 const { SIGN_IN } = ROUTE_HANDLER_PATH.AUTH;
 const { BASE_URL } = ENV;
 
-// NextAuth 설정 옵션을 정의합니다.
 export const authOptions: NextAuthOptions = {
-  // PrismaAdapter를 사용하여 Prisma와의 연결을 설정합니다.
   adapter: PrismaAdapter(prisma),
 
   providers: [
@@ -35,7 +33,6 @@ export const authOptions: NextAuthOptions = {
         password: { label: '비밀번호', type: 'password' },
       },
 
-      // 이메일, 패스워드 부분을 체크해서 맞으면 user 객체 리턴 틀리면 null 리턴
       async authorize(credentials, req) {
         const res = await fetch(`${BASE_URL}/${SIGN_IN}`, {
           method: POST,
@@ -56,7 +53,6 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
 
-  // 인증 과정에서 사용할 콜백 함수를 정의합니다.
   callbacks: {
     async jwt({ token, user }) {
       if ((user as any)?.accessToken) {
@@ -65,21 +61,16 @@ export const authOptions: NextAuthOptions = {
       return token;
     },
 
-    // 세션이 생성될 때 호출되는 콜백 함수입니다.
     async session({ session, token }) {
       if (token?.accessToken) {
         (session as any).accessToken = token.accessToken;
       }
       if (token?.sub) {
-        session.user.id = token.sub; // 세션에 사용자 ID를 추가
+        session.user.id = token.sub;
       }
       return session;
     },
   },
-
-  // 사용자 정의 로그인 페이지 경로를 설정합니다.
-  // 원래의 경우라면, 로그인 페이지가 없어서 기본 로그인 페이지로 리디렉션됩니다.
-  // 하지만, 우리는 사용자 정의 로그인 페이지를 사용하기 때문에 이 설정을 추가합니다.
 
   pages: {
     signIn: '/auth/sign-in',


### PR DESCRIPTION
## 💡 관련이슈

- #182

## 🍀 작업 요약

> middleware를 통해 미인증 사용자가 페이지 접근 시 해당 페이지의 url을 가진 상태로 sign-in 페이지로 redirect
> 로그인 성공 시 쿼리 파라미터 prevUrl을 통해 이전 url로 redirect
> 로그인 실패 시 callbackUrl을 prevUrl로 갖고 sign-in 페이지로 redirect

## 💬 리뷰 요구 사항

> nope

## 💛 미리보기
![redirect](https://github.com/user-attachments/assets/298d90c1-056e-4518-bfd5-d09f8f552e00)

### ✔️ 이슈 닫기

Closes #182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 로그인 후 사용자가 이전 페이지나 의도한 페이지로 리디렉션될 수 있도록 지원이 추가되었습니다.

- **버그 수정**
  - 로그인 오류 발생 시 리디렉션 로직이 개선되어, 적절한 페이지로 이동하도록 수정되었습니다.

- **스타일**
  - 코드 내 불필요한 주석이 제거되어 코드가 더 간결해졌습니다.

- **스타일**
  - 사용자 이름 표시 영역의 너비 조정으로 레이아웃 유연성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->