### PR TITLE
Bugfix/#172 button tab counting

### DIFF
--- a/src/app/api/interview-history/[userId]/route.ts
+++ b/src/app/api/interview-history/[userId]/route.ts
@@ -6,6 +6,7 @@ import { ENV } from '@/constants/env-constants';
 import { AUTH_MESSAGE, HISTORY_MESSAGE, INTERVIEW_HISTORY } from '@/constants/message-constants';
 import { formatDate } from '@/utils/format-date';
 import { sanitizeQueryParams } from '@/utils/sanitize-query-params';
+import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
 
 type Props = {
   params: {
@@ -22,8 +23,7 @@ const {
 const {
   API: { GET_ERROR },
 } = INTERVIEW_HISTORY;
-
-const COMPLETED_INTERVIEW_CODE = 1;
+const { COMPLETED } = INTERVIEW_HISTORY_STATUS;
 
 export const GET = async (request: NextRequest, { params }: Props) => {
   try {
@@ -43,7 +43,7 @@ export const GET = async (request: NextRequest, { params }: Props) => {
     }
 
     const histories = await prisma.interviewHistory.findMany({
-      where: { userId: userId, status: COMPLETED_INTERVIEW_CODE },
+      where: { userId: userId, status: COMPLETED },
       orderBy: { createdAt: 'desc' },
       include: {
         resume: true,
@@ -53,7 +53,7 @@ export const GET = async (request: NextRequest, { params }: Props) => {
     });
 
     const totalCount = await prisma.interviewHistory.count({
-      where: { userId, status: COMPLETED_INTERVIEW_CODE },
+      where: { userId, status: COMPLETED },
     });
     const nextPage = pageNumber * limitNumber < totalCount ? pageNumber + 1 : null;
     if (!histories) return NextResponse.json({ data: [], nextPage }, { status: 200 });

--- a/src/app/api/my-page/tab-counts/[userId]/route.ts
+++ b/src/app/api/my-page/tab-counts/[userId]/route.ts
@@ -28,7 +28,7 @@ type Props = {
 };
 export const GET = async (request: NextRequest, { params }: Props) => {
   try {
-    const token = getToken({ req: request, secret: NEXTAUTH_SECRET });
+    const token = await getToken({ req: request, secret: NEXTAUTH_SECRET });
     if (!token) return NextResponse.json({ message: EXPIRED_TOKEN }, { status: 401 });
     const { userId } = params;
     const res = await prisma.user.findUnique({

--- a/src/app/api/my-page/tab-counts/[userId]/route.ts
+++ b/src/app/api/my-page/tab-counts/[userId]/route.ts
@@ -1,0 +1,50 @@
+import { prisma } from '@/lib/prisma';
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+import type { User } from '@prisma/client';
+import { ENV } from '@/constants/env-constants';
+import { AUTH_MESSAGE, TAB_COUNT_MESSAGE } from '@/constants/message-constants';
+import { INIT_TAB_COUNTS, TABS } from '@/constants/my-page-constants';
+
+const { NEXTAUTH_SECRET } = ENV;
+
+const {
+  ERROR: { EXPIRED_TOKEN },
+} = AUTH_MESSAGE;
+
+const {
+  API: { SERVER_ERROR },
+} = TAB_COUNT_MESSAGE;
+
+const { HISTORY, RESUME, BOOKMARK } = TABS;
+
+type Props = {
+  params: {
+    userId: User['id'];
+  };
+};
+export const GET = async (request: NextRequest, { params }: Props) => {
+  try {
+    const token = getToken({ req: request, secret: NEXTAUTH_SECRET });
+    if (!token) return NextResponse.json({ message: EXPIRED_TOKEN }, { status: 401 });
+    const { userId } = params;
+    const res = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        _count: {
+          select: {
+            [RESUME]: true,
+            [HISTORY]: true,
+            [BOOKMARK]: true,
+          },
+        },
+      },
+    });
+
+    const tabCounts = res?._count ?? INIT_TAB_COUNTS;
+
+    return NextResponse.json({ response: tabCounts }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ message: SERVER_ERROR }, { status: 500 });
+  }
+};

--- a/src/app/api/my-page/tab-counts/[userId]/route.ts
+++ b/src/app/api/my-page/tab-counts/[userId]/route.ts
@@ -5,6 +5,7 @@ import type { User } from '@prisma/client';
 import { ENV } from '@/constants/env-constants';
 import { AUTH_MESSAGE, TAB_COUNT_MESSAGE } from '@/constants/message-constants';
 import { INIT_TAB_COUNTS, TABS } from '@/constants/my-page-constants';
+import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
 
 const { NEXTAUTH_SECRET } = ENV;
 
@@ -17,6 +18,8 @@ const {
 } = TAB_COUNT_MESSAGE;
 
 const { HISTORY, RESUME, BOOKMARK } = TABS;
+
+const { COMPLETED } = INTERVIEW_HISTORY_STATUS;
 
 type Props = {
   params: {
@@ -34,8 +37,12 @@ export const GET = async (request: NextRequest, { params }: Props) => {
         _count: {
           select: {
             [RESUME]: true,
-            [HISTORY]: true,
             [BOOKMARK]: true,
+            [HISTORY]: {
+              where: {
+                status: COMPLETED,
+              },
+            },
           },
         },
       },

--- a/src/constants/message-constants.ts
+++ b/src/constants/message-constants.ts
@@ -134,3 +134,9 @@ export const INTERVIEW_QNA_MESSAGE = {
     NOT_FOUND: '해당 QnA의 ID를 찾을 수 없습니다.',
   },
 };
+
+export const TAB_COUNT_MESSAGE = {
+  API: {
+    SERVER_ERROR: '리스트 개수를 가져오는데 실패했습니다.',
+  },
+};

--- a/src/constants/my-page-constants.ts
+++ b/src/constants/my-page-constants.ts
@@ -3,3 +3,10 @@ export const TABS = {
   BOOKMARK: 'userSelectedJobs',
   RESUME: 'resumes',
 } as const;
+
+const { HISTORY, BOOKMARK, RESUME } = TABS;
+export const INIT_TAB_COUNTS = {
+  [HISTORY]: 0,
+  [BOOKMARK]: 0,
+  [RESUME]: 0,
+};

--- a/src/constants/path-constant.ts
+++ b/src/constants/path-constant.ts
@@ -1,3 +1,5 @@
+import type { User } from '@prisma/client';
+
 export const PATH = {
   MAIN: '/',
   AUTH: {
@@ -43,6 +45,7 @@ export const ROUTE_HANDLER_PATH = {
   },
   USER: {
     META_DATA: '/api/user-meta-data',
+    LIST_COUNT: (userId: User['id']) => `/api/my-page/tab-counts/${userId}`,
     INTERVIEW_HISTORY: '/api/interview-history',
     INTERVIEW_DETAIL: (id: number) => `/api/ai/interview/${id}`,
   },

--- a/src/constants/query-key.ts
+++ b/src/constants/query-key.ts
@@ -8,4 +8,5 @@ export const QUERY_KEY = {
   JOB_POSTING: 'job-posting',
   CHARACTER_HISTORIES: 'characterHistories',
   HISTORY: 'interview-history',
+  TABS_COUNT: 'tabs-count',
 };

--- a/src/features/bookmark-selected/bookmark-tab.tsx
+++ b/src/features/bookmark-selected/bookmark-tab.tsx
@@ -1,13 +1,12 @@
 import { Star } from '@/components/icons/star';
-import Typography from '@/components/ui/typography';
-import { JobPosting, UserSelectedJob } from '@prisma/client';
-import { formatRemainDay } from '@/utils/format-remain-day';
-import clsx from 'clsx';
 import Button from '@/components/ui/button';
-import { useBookmarkMutation } from '@/features/job/hooks/use-bookmark-mutation';
-import { formatTimestamp } from '@/utils/format-timestamp';
-import { useQueryClient } from '@tanstack/react-query';
+import Typography from '@/components/ui/typography';
 import { QUERY_KEY } from '@/constants/query-key';
+import { useBookmarkMutation } from '@/features/job/hooks/use-bookmark-mutation';
+import { formatRemainDay } from '@/utils/format-remain-day';
+import { formatTimestamp } from '@/utils/format-timestamp';
+import { JobPosting, UserSelectedJob } from '@prisma/client';
+import clsx from 'clsx';
 
 const experienceType: Record<number, string> = {
   0: '경력무관',
@@ -23,8 +22,7 @@ type Props = {
   userId: string;
 };
 const BookmarkTab = ({ bookmark, index, length, userId }: Props) => {
-  const queryClient = useQueryClient();
-  const { mutateAsync: bookmarkMutate } = useBookmarkMutation({
+  const { mutate: bookmarkMutate } = useBookmarkMutation({
     jobPostingId: bookmark.jobPostingId,
     userId,
   });
@@ -36,14 +34,8 @@ const BookmarkTab = ({ bookmark, index, length, userId }: Props) => {
   const expiredAtDate = formatTimestamp({ input: jobPosting.expirationTimestamp });
   const remainDay = formatRemainDay(jobPosting.expirationTimestamp);
 
-  const handleDeleteBookmark = async () => {
-    try {
-      /* TODO: alert 로직 구현 */
-      await bookmarkMutate(true);
-      queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
-    } catch (error) {
-      if (error instanceof Error) alert(error.message);
-    }
+  const handleDeleteBookmark = () => {
+    bookmarkMutate(true);
   };
 
   return (

--- a/src/features/bookmark-selected/bookmark-tab.tsx
+++ b/src/features/bookmark-selected/bookmark-tab.tsx
@@ -6,6 +6,8 @@ import clsx from 'clsx';
 import Button from '@/components/ui/button';
 import { useBookmarkMutation } from '@/features/job/hooks/use-bookmark-mutation';
 import { formatTimestamp } from '@/utils/format-timestamp';
+import { useQueryClient } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/constants/query-key';
 
 const experienceType: Record<number, string> = {
   0: '경력무관',
@@ -13,7 +15,7 @@ const experienceType: Record<number, string> = {
   2: '경력',
   3: '신입/경력',
 };
-
+const { TABS_COUNT } = QUERY_KEY;
 type Props = {
   bookmark: UserSelectedJob & { jobPosting: JobPosting };
   index: number;
@@ -21,7 +23,8 @@ type Props = {
   userId: string;
 };
 const BookmarkTab = ({ bookmark, index, length, userId }: Props) => {
-  const { mutate: bookmarkMutate } = useBookmarkMutation({
+  const queryClient = useQueryClient();
+  const { mutateAsync: bookmarkMutate } = useBookmarkMutation({
     jobPostingId: bookmark.jobPostingId,
     userId,
   });
@@ -34,8 +37,13 @@ const BookmarkTab = ({ bookmark, index, length, userId }: Props) => {
   const remainDay = formatRemainDay(jobPosting.expirationTimestamp);
 
   const handleDeleteBookmark = async () => {
-    /* TODO: alert 로직 구현 */
-    bookmarkMutate(true);
+    try {
+      /* TODO: alert 로직 구현 */
+      await bookmarkMutate(true);
+      queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
+    } catch (error) {
+      if (error instanceof Error) alert(error.message);
+    }
   };
 
   return (

--- a/src/features/interview-history/hook/use-delete-interview-mutation.ts
+++ b/src/features/interview-history/hook/use-delete-interview-mutation.ts
@@ -26,7 +26,9 @@ export const useDeleteInterviewMutation = () => {
 
       return { previousInterviewList };
     },
-
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
+    },
     onError: (err, interviewId, context) => {
       if (context?.previousInterviewList) {
         queryClient.setQueryData([HISTORY], context.previousInterviewList);
@@ -36,7 +38,7 @@ export const useDeleteInterviewMutation = () => {
 
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [HISTORY] });
-      queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
+
       router.push(MY_PAGE);
     },
   });

--- a/src/features/interview-history/hook/use-delete-interview-mutation.ts
+++ b/src/features/interview-history/hook/use-delete-interview-mutation.ts
@@ -5,7 +5,7 @@ import { deleteInterview } from '@/features/interview-history/api/client-service
 import { useRouter } from 'next/navigation';
 import { PATH } from '@/constants/path-constant';
 
-const { HISTORY } = QUERY_KEY;
+const { HISTORY, TABS_COUNT } = QUERY_KEY;
 const { MY_PAGE } = PATH;
 
 export const useDeleteInterviewMutation = () => {
@@ -36,6 +36,7 @@ export const useDeleteInterviewMutation = () => {
 
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [HISTORY] });
+      queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
       router.push(MY_PAGE);
     },
   });

--- a/src/features/interview-history/hook/use-delete-interview-mutation.ts
+++ b/src/features/interview-history/hook/use-delete-interview-mutation.ts
@@ -31,6 +31,7 @@ export const useDeleteInterviewMutation = () => {
       if (context?.previousInterviewList) {
         queryClient.setQueryData([HISTORY], context.previousInterviewList);
       }
+      throw err;
     },
 
     onSettled: () => {

--- a/src/features/interview-history/interview-detail-feedback.tsx
+++ b/src/features/interview-history/interview-detail-feedback.tsx
@@ -2,7 +2,7 @@ import ImprovementIcon from '@/components/icons/improvement-icon';
 import StrengthIcon from '@/components/icons/strength-icon';
 import Button from '@/components/ui/button';
 import Typography from '@/components/ui/typography';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 type Props = {
   feedback: FeedbackItem[];
@@ -32,9 +32,9 @@ const InterviewDetailFeedback = ({ feedback }: Props) => {
   return (
     <div>
       <div className='flex flex-col gap-4'>
-        <div className='ml-4 flex flex-wrap gap-2'>
+        <div className='flex flex-wrap gap-2 px-4'>
           {Object.keys(FEEDBACK_KEYS).map((key) => (
-            <div key={key} className='min-w-[84px]'>
+            <div key={key}>
               <Button
                 onClick={() => setActiveTab(key)}
                 variant={activeTab === key ? 'contained' : 'outline'}

--- a/src/features/interview-history/interview-detail-field.tsx
+++ b/src/features/interview-history/interview-detail-field.tsx
@@ -1,17 +1,15 @@
+import ErrorComponent from '@/components/common/error-component';
 import LeftArrowIcon from '@/components/icons/left-arrow-icon';
+import Button from '@/components/ui/button';
+import LoadingSpinner from '@/components/ui/loading-spinner';
 import Typography from '@/components/ui/typography';
 import { PATH } from '@/constants/path-constant';
-import Link from 'next/link';
-import { useState } from 'react';
+import { useDeleteInterviewMutation } from '@/features/interview-history/hook/use-delete-interview-mutation';
+import { useGetInterviewDetailQuery } from '@/features/interview-history/hook/use-get-interview-detail-query';
 import InterviewDetailFeedback, { FeedbackItem } from '@/features/interview-history/interview-detail-feedback';
 import InterviewDetailHistory from '@/features/interview-history/interview-detail-history';
-import LoadingSpinner from '@/components/ui/loading-spinner';
-import ErrorComponent from '@/components/common/error-component';
-import { useGetInterviewDetailQuery } from '@/features/interview-history/hook/use-get-interview-detail-query';
-import { useDeleteInterviewMutation } from '@/features/interview-history/hook/use-delete-interview-mutation';
-import Button from '@/components/ui/button';
-import { useQueryClient } from '@tanstack/react-query';
-import { QUERY_KEY } from '@/constants/query-key';
+import Link from 'next/link';
+import { useState } from 'react';
 
 type Props = {
   id: number;
@@ -22,12 +20,11 @@ const SELECT_ACTIVE_TAB = {
   FEEDBACK: 'feedback',
   HISTORY: 'history',
 };
-const { TABS_COUNT } = QUERY_KEY;
+
 const InterviewDetailField = ({ id }: Props) => {
   const [activeTab, setActiveTab] = useState<string>('feedback');
   const { data, isPending, isError } = useGetInterviewDetailQuery(id);
-  const { mutateAsync: deleteInterviewMutation } = useDeleteInterviewMutation();
-  const queryClient = useQueryClient();
+  const { mutate: deleteInterviewMutation } = useDeleteInterviewMutation();
 
   if (isPending)
     return (
@@ -44,13 +41,8 @@ const InterviewDetailField = ({ id }: Props) => {
 
   const feedback = data.feedback as FeedbackItem[];
 
-  const handleDelete = async () => {
-    try {
-      await deleteInterviewMutation(id);
-      queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
-    } catch (error) {
-      if (error instanceof Error) alert(error.message);
-    }
+  const handleDelete = () => {
+    deleteInterviewMutation(id);
   };
 
   return (

--- a/src/features/interview/timer.tsx
+++ b/src/features/interview/timer.tsx
@@ -12,10 +12,12 @@ import { useExperienceUp } from '@/features/character/hooks/use-experience-up';
 import { usePatchInterviewHistoryMutation } from '@/features/interview/hooks/use-interview-history-mutation';
 import { usePostAIFeedbackMutation } from '@/features/interview/hooks/use-ai-feedback-mutation';
 import type { InterviewHistory } from '@prisma/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/constants/query-key';
 
 const { MY_PAGE } = PATH;
 const { INTERVIEW_COMPLETION } = CHARACTER_HISTORY_KEY;
-
+const { TABS_COUNT } = QUERY_KEY;
 type Props = {
   interviewHistory: InterviewHistory;
   isRecording: boolean;
@@ -39,7 +41,7 @@ const Timer = ({
   const router = useRouter();
   const { mutate: patchInterviewHistoryMutate, error: InterviewHistoryError } = usePatchInterviewHistoryMutation();
   const { mutate: postAIFeedbackMutate, error: aiFeedbackError } = usePostAIFeedbackMutation();
-
+  const queryClient = useQueryClient();
   const characterId = useCharacterStore((state) => state.characterId);
   const { handleExperienceUp } = useExperienceUp();
 
@@ -73,6 +75,10 @@ const Timer = ({
 
     patchInterviewHistoryMutate(interviewHistory.id);
     postAIFeedbackMutate(interviewHistory.id);
+    //여기 충돌날 거 같아요! 이부분 마이 페이지 버튼 카운팅에 필요한 부분입니다 충돌 해결이 어렵다면 저(이다혜)를 찔러주세여!
+    queryClient.invalidateQueries({
+      queryKey: [TABS_COUNT],
+    });
     router.push(MY_PAGE);
   };
 

--- a/src/features/job/bookmark.tsx
+++ b/src/features/job/bookmark.tsx
@@ -22,8 +22,12 @@ const Bookmark = ({ jobPostingId, isBookmarked, userId }: Props) => {
   const router = useRouter();
 
   const handleClick = async () => {
-    await bookmarkMutate(isBookmarked);
-    queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
+    try {
+      await bookmarkMutate(isBookmarked);
+      queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
+    } catch (error) {
+      if (error instanceof Error) alert(error.message);
+    }
 
     // TODO: alert 구현
   };

--- a/src/features/job/bookmark.tsx
+++ b/src/features/job/bookmark.tsx
@@ -7,6 +7,9 @@ import { useRouter } from 'next/navigation';
 
 const { SIGN_IN } = PATH.AUTH;
 
+import { useQueryClient } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/constants/query-key';
+const { TABS_COUNT } = QUERY_KEY;
 type Props = {
   jobPostingId: number;
   isBookmarked: boolean;
@@ -14,11 +17,14 @@ type Props = {
 };
 
 const Bookmark = ({ jobPostingId, isBookmarked, userId }: Props) => {
-  const { mutate: bookmarkMutate, isError } = useBookmarkMutation({ jobPostingId, userId });
+  const queryClient = useQueryClient();
+  const { mutateAsync: bookmarkMutate, isError } = useBookmarkMutation({ jobPostingId, userId });
   const router = useRouter();
 
-  const handleClick = () => {
-    bookmarkMutate(isBookmarked);
+  const handleClick = async () => {
+    await bookmarkMutate(isBookmarked);
+    queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
+
     // TODO: alert 구현
   };
 

--- a/src/features/job/hooks/use-bookmark-mutation.ts
+++ b/src/features/job/hooks/use-bookmark-mutation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postBookmarkWithJobPostingId } from '@/features/job/api/client-services';
 import { QUERY_KEY } from '@/constants/query-key';
 
-const { BOOKMARK, JOB_POSTING } = QUERY_KEY;
+const { BOOKMARK, JOB_POSTING, TABS_COUNT } = QUERY_KEY;
 
 type Props = {
   jobPostingId: number;
@@ -27,6 +27,7 @@ export const useBookmarkMutation = ({ jobPostingId, userId }: Props) => {
           queryKey: [JOB_POSTING, userId],
         });
         queryClient.invalidateQueries({ queryKey: [BOOKMARK, userId] });
+        queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
       }
     },
     onError: (error) => {

--- a/src/features/my-page/api/client-services.ts
+++ b/src/features/my-page/api/client-services.ts
@@ -1,0 +1,23 @@
+import type { User } from '@prisma/client';
+import { fetchWithSentry } from '@/utils/fetch-with-sentry';
+import { API_HEADER, API_METHOD } from '@/constants/api-method-constants';
+import { ROUTE_HANDLER_PATH } from '@/constants/path-constant';
+
+const {
+  USER: { LIST_COUNT },
+} = ROUTE_HANDLER_PATH;
+const { GET } = API_METHOD;
+const { JSON_HEADER } = API_HEADER;
+
+/**
+ * 면접기록, 북마크한 채용공고, 내가 작성한 자소서의 개수를 반환
+ * @param userId - 현재 로그인 중인 user의 id
+ * @returns 면접기록 / 북마크한 채용공고 / 내가 작성한 자소서의 개수
+ */
+export const getTabCount = async (userId: User['id']) => {
+  const { response } = await fetchWithSentry(LIST_COUNT(userId), {
+    method: GET,
+    headers: JSON_HEADER,
+  });
+  return response;
+};

--- a/src/features/my-page/hook/use-tab-count-query.ts
+++ b/src/features/my-page/hook/use-tab-count-query.ts
@@ -1,0 +1,24 @@
+import type { User } from '@prisma/client';
+import { useQuery } from '@tanstack/react-query';
+import { getTabCount } from '@/features/my-page/api/client-services';
+import { STALE_TIME } from '@/constants/time-constants';
+import { QUERY_KEY } from '@/constants/query-key';
+const { TABS_COUNT } = QUERY_KEY;
+const { A_DAY } = STALE_TIME;
+
+export const useTabCountQuery = (
+  userId: User['id'] | null,
+  initialData?: {
+    resumes: number;
+    interviewHistories: number;
+    userSelectedJobs: number;
+  }
+) => {
+  return useQuery({
+    queryKey: [TABS_COUNT],
+    queryFn: () => getTabCount(userId!),
+    enabled: !!userId,
+    staleTime: A_DAY,
+    initialData,
+  });
+};

--- a/src/features/my-page/tab-buttons.tsx
+++ b/src/features/my-page/tab-buttons.tsx
@@ -2,9 +2,10 @@
 import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useTabStore } from '@/store/use-tab-store';
+import { useTabCountQuery } from '@/features/my-page/hook/use-tab-count-query';
 import Badge from '@/components/ui/badge';
-import { TABS } from '@/constants/my-page-constants';
 import type { Tabs } from '@/types/tab-type';
+import { TABS } from '@/constants/my-page-constants';
 
 const { BOOKMARK, RESUME, HISTORY } = TABS;
 
@@ -24,22 +25,27 @@ const tabs = [
 ];
 
 type Props = {
-  tabCounts: {
-    resumes: number;
-    interviewHistories: number;
-    userSelectedJobs: number;
+  userId: string;
+  initialTabCounts: {
+    [RESUME]: number;
+    [HISTORY]: number;
+    [BOOKMARK]: number;
   };
 };
 
-const TabButtons = ({ tabCounts }: Props) => {
+const TabButtons = ({ userId, initialTabCounts }: Props) => {
   const { setTab, tab: targetTab, resetTab } = useTabStore();
   const handleChangeTab = (newTab: Tabs) => {
     if (newTab === RESUME) return; //@TODO: 아직 자소서쪽이 미완이라 일단 tab change는 막아두겠습니다.
     setTab(newTab);
   };
+
   useEffect(() => {
     return () => resetTab();
   }, []);
+
+  const { data: tabCounts } = useTabCountQuery(userId, initialTabCounts);
+
   return (
     <ul className='flex h-12 items-center justify-evenly bg-cool-gray-100'>
       {tabs.map((tab) => (
@@ -59,9 +65,6 @@ const TabButtons = ({ tabCounts }: Props) => {
               <Badge mx={1} size='small' color='dark'>
                 {tabCounts[tab.id]}
               </Badge>
-              // <span className='mx-1 rounded-xl bg-cool-gray-900 px-[10px] py-[2px] text-xs text-cool-gray-50'>
-              //   {tabCounts[tab.id]}개
-              // </span>
             )}
           </button>
         </li>

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -3,7 +3,9 @@ import type { User } from '@prisma/client';
 import ListByTab from '@/features/my-page/list-by-tab';
 import TabButtons from '@/features/my-page/tab-buttons';
 import { INIT_TAB_COUNTS } from '@/constants/my-page-constants';
+import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
 
+const { COMPLETED } = INTERVIEW_HISTORY_STATUS;
 type Props = {
   userId: User['id'];
 };
@@ -14,7 +16,11 @@ const TabsField = async ({ userId }: Props) => {
       _count: {
         select: {
           resumes: true,
-          interviewHistories: true,
+          interviewHistories: {
+            where: {
+              status: COMPLETED,
+            },
+          },
           userSelectedJobs: true,
         },
       },

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import type { User } from '@prisma/client';
 import ListByTab from '@/features/my-page/list-by-tab';
 import TabButtons from '@/features/my-page/tab-buttons';
+import { INIT_TAB_COUNTS } from '@/constants/my-page-constants';
 
 type Props = {
   userId: User['id'];
@@ -20,15 +21,11 @@ const TabsField = async ({ userId }: Props) => {
     },
   });
 
-  const tabCounts = result?._count ?? {
-    resumes: 0,
-    interviewHistories: 0,
-    userSelectedJobs: 0,
-  };
+  const initialTabCounts = result?._count ?? INIT_TAB_COUNTS;
 
   return (
     <section className='h-[80dvh] max-h-[643px] w-1/2 max-w-[634px] rounded-t-[8px] border bg-cool-gray-10'>
-      <TabButtons tabCounts={tabCounts} />
+      <TabButtons userId={userId} initialTabCounts={initialTabCounts} />
       <div className='h-full p-8'>
         <ListByTab />
       </div>

--- a/src/features/user-meta-data/hooks/use-meta-data-form.ts
+++ b/src/features/user-meta-data/hooks/use-meta-data-form.ts
@@ -31,7 +31,7 @@ const { JOB_POSTING } = QUERY_KEY;
 
 export const useMetaDataForm = (userId: string) => {
   const { data: metaData, isPending: isMetaDataPending } = useMetaDataQuery({ userId });
-  const { mutate, error } = useMetaDataMutation(userId);
+  const { mutateAsync, error } = useMetaDataMutation(userId);
   const toggleModal = useModalStore((state) => state.toggleModal);
   const { handleExperienceUp } = useExperienceUp();
   const characterId = useCharacterStore((state) => state.characterId);
@@ -86,18 +86,19 @@ export const useMetaDataForm = (userId: string) => {
     [setValue, trigger]
   );
 
-  const handleOnSubmit = (values: UserMetaDataType) => {
-    mutate(values, {
-      onSuccess: () => {
-        if (isFirstTime) handleExperienceUp(FILL_OUT_META_DATA);
-        alert(isFirstTime ? CHARACTER_POST_SUCCESS : POST_DATA_SUCCESS);
-        toggleModal(USER_META_DATA);
-        queryClient.invalidateQueries({
-          queryKey: [JOB_POSTING, userId],
-          exact: true,
-        });
-      },
-    });
+  const handleOnSubmit = async (values: UserMetaDataType) => {
+    try {
+      await mutateAsync(values);
+      if (isFirstTime) handleExperienceUp(FILL_OUT_META_DATA);
+      alert(isFirstTime ? CHARACTER_POST_SUCCESS : POST_DATA_SUCCESS);
+      toggleModal(USER_META_DATA);
+      queryClient.invalidateQueries({
+        queryKey: [JOB_POSTING, userId],
+        exact: true,
+      });
+    } catch (error) {
+      if (error instanceof Error) alert(error.message);
+    }
   };
 
   return {


### PR DESCRIPTION
## 💡 관련이슈

#172 

## 🍀 작업 요약

- 마이 페이지 > tab count가 제대로 반영되지 않는 문제 수정했습니다.
- 서버렌더링을 통해 초기 데이터를 주입하는 방식을 택했습니다. -> 새로고침 시 탭부분에 로딩바 뜨는 것이 거슬림 
- 그 이후부터는 useQuery를 사용하여 클라이언트에서 관리하도록 하였습니다. 
- 따라서 tabCount 업데이트가 필요한 곳에서는 queryKey `tabs-count`를 사용하여 `invalidateQueries` 진행해 주시길 바랍니다.
- 현재 dev 기준으로 tab counting이 필요한 곳(
마이페이지 > 면접기록 삭제 , 북마크 삭제
채용공고 > 북마크 추가&삭제 
AI 면접 > 면접 완료 
이력서 작성 페이지 > 작성 완료)은 적용해놨습니다만 
아직 민조님 작업이 되지 않은 마이페이지 > 이력서 쪽은 작업되어 있지 않으니 추가 작업 부탁드립니다.


## 💬 리뷰 요구 사항

- tab count 반영이 잘 되는지 테스트 부탁드립니다.

## 💛 미리보기

> 사진이나 gif 등 미리 볼 수 있는 파일을 제공해주세요.

### ✔️ 이슈 닫기

Closes #172 
Ref #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝나지 않은 경우


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 마이페이지에서 사용자의 이력서, 북마크, 면접 기록(완료 상태 기준) 개수를 조회하는 API 및 클라이언트 훅이 추가되었습니다.
  - 탭별 개수 정보를 실시간으로 반영하여 표시하도록 UI가 개선되었습니다.

- **버그 수정**
  - 면접 기록 개수 집계 시 완료된 항목만 포함하도록 수정되었습니다.

- **개선 및 리팩터**
  - 북마크, 면접 기록, 이력서 관련 삭제/변경 시 탭 개수 정보가 자동으로 갱신되도록 캐시 무효화 로직이 추가되었습니다.
  - 여러 컴포넌트에서 비동기 처리와 에러 핸들링이 강화되었습니다.

- **문서 및 상수 추가**
  - 탭 개수 관련 메시지, 초기값, 쿼리 키, API 경로 상수가 새로 도입되었습니다.

- **컴포넌트 인터페이스 변경**
  - TabButtons 컴포넌트가 개별 탭 개수 대신 userId와 초기 개수를 props로 받도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->