### PR TITLE
bugfix:#191 마이페이지 > 내가 작성한 자소서 삭제 시 tab count 반영되도록 수정

### DIFF
--- a/src/app/api/my-page/tab-counts/[userId]/route.ts
+++ b/src/app/api/my-page/tab-counts/[userId]/route.ts
@@ -6,6 +6,7 @@ import { ENV } from '@/constants/env-constants';
 import { AUTH_MESSAGE, TAB_COUNT_MESSAGE } from '@/constants/message-constants';
 import { INIT_TAB_COUNTS, TABS } from '@/constants/my-page-constants';
 import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
+import { RESUME_STATUS } from '@/constants/resume-constants';
 
 const { NEXTAUTH_SECRET } = ENV;
 
@@ -20,6 +21,7 @@ const {
 const { HISTORY, RESUME, BOOKMARK } = TABS;
 
 const { COMPLETED } = INTERVIEW_HISTORY_STATUS;
+const { SUBMIT } = RESUME_STATUS;
 
 type Props = {
   params: {
@@ -36,7 +38,11 @@ export const GET = async (request: NextRequest, { params }: Props) => {
       select: {
         _count: {
           select: {
-            [RESUME]: true,
+            [RESUME]: {
+              where: {
+                status: SUBMIT,
+              },
+            },
             [BOOKMARK]: true,
             [HISTORY]: {
               where: {

--- a/src/app/global-style.css
+++ b/src/app/global-style.css
@@ -115,6 +115,22 @@
   .border-cool-gray-50 {
     border-color: #f9fafb;
   }
+  /* nav shadow */
+  .nav-shadow {
+    box-shadow:
+      1px 1px 1px 0px rgba(255, 255, 255, 0.7) inset,
+      -1px -1px 1px 0px rgba(0, 0, 0, 0.23) inset,
+      0.445px 0.445px 0.629px -0.75px rgba(0, 0, 0, 0.26),
+      1.211px 1.211px 1.712px -1.5px rgba(0, 0, 0, 0.25),
+      2.658px 2.658px 3.759px -2.25px rgba(0, 0, 0, 0.23),
+      5.901px 5.901px 8.345px -3px rgba(0, 0, 0, 0.19),
+      14px 14px 21.213px -3.75px rgba(0, 0, 0, 0.2),
+      -0.5px -0.5px 0px 0px rgba(0, 0, 0, 0.69);
+  }
+  /* default text-balance */
+  .text-balance {
+    text-wrap: balance;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -128,10 +144,4 @@ body {
   color: var(--foreground);
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
-}
-
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
 }

--- a/src/constants/path-constant.ts
+++ b/src/constants/path-constant.ts
@@ -66,3 +66,10 @@ export const QUERY_PARAMS = {
   ERROR: 'error',
   UNAUTH: 'unauthorized',
 };
+
+const {
+  RESUME: { ROOT },
+  INTERVIEW: { START },
+  JOB,
+} = PATH;
+export const PUBLIC_PAGE = [ROOT, START, JOB]; //비회원도 접근할 수 있는 페이지

--- a/src/features/layout/button-nav.tsx
+++ b/src/features/layout/button-nav.tsx
@@ -1,8 +1,9 @@
 'use client';
-
+import { useMemo } from 'react';
 import { signOut } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { NavItems } from '@/features/layout/data/nav-items';
+import { PUBLIC_PAGE } from '@/constants/path-constant';
 
 type Props = {
   menu: NavItems;
@@ -10,9 +11,12 @@ type Props = {
 
 const ButtonNav = ({ menu }: Props) => {
   const router = useRouter();
+  const currentPath = usePathname();
+  const isPublicPage = useMemo(() => PUBLIC_PAGE.includes(currentPath), [currentPath]);
+
   const handleNavigate = async () => {
     await signOut({ redirect: false }).then(() => {
-      router.replace(menu.path);
+      if (!isPublicPage) router.replace(menu.path);
       router.refresh();
     });
   };

--- a/src/features/layout/data/nav-items.tsx
+++ b/src/features/layout/data/nav-items.tsx
@@ -71,10 +71,4 @@ export const Public_Nav_Items: NavItems[] = [
     icon: <SignInIcon />,
     class: 'mb-2',
   },
-  // {
-  //   path: AUTH.SIGN_UP,
-  //   name: '회원가입',
-  //   type: 'link',
-  //   icon: <SignUpIcon />,
-  // },
 ];

--- a/src/features/layout/nav.tsx
+++ b/src/features/layout/nav.tsx
@@ -19,21 +19,7 @@ export const Nav = ({ session }: Props) => {
   const menus: NavItems[] = useMemo(() => (session ? Private_Nav_Items : Public_Nav_Items), [session]);
 
   return (
-    <nav
-      style={{
-        boxShadow: `
-        1px 1px 1px 0px rgba(255, 255, 255, 0.70) inset,
-        -1px -1px 1px 0px rgba(0, 0, 0, 0.23) inset,
-        0.445px 0.445px 0.629px -0.75px rgba(0, 0, 0, 0.26),
-        1.211px 1.211px 1.712px -1.5px rgba(0, 0, 0, 0.25),
-        2.658px 2.658px 3.759px -2.25px rgba(0, 0, 0, 0.23),
-        5.901px 5.901px 8.345px -3px rgba(0, 0, 0, 0.19),
-        14px 14px 21.213px -3.75px rgba(0, 0, 0, 0.20),
-        -0.5px -0.5px 0px 0px rgba(0, 0, 0, 0.69)
-      `,
-      }}
-      className='flex h-screen w-[52px] flex-col items-center justify-center bg-cool-gray-900 px-1 py-8 text-cool-gray-50'
-    >
+    <nav className='nav-shadow flex h-screen w-[52px] flex-col items-center justify-center bg-cool-gray-900 px-1 py-8 text-cool-gray-50'>
       <Link href={ON_BOARDING} className='mb-12 block'>
         <ChickLogo />
       </Link>

--- a/src/features/my-page/tab-buttons.tsx
+++ b/src/features/my-page/tab-buttons.tsx
@@ -19,7 +19,7 @@ const tabs = [
     title: '북마크한 채용공고',
   },
   {
-    id: RESUME, //@TODO:  zustand 타입에도 추가 부탁드립니다.
+    id: RESUME,
     title: '내가 작성한 자소서',
   },
 ];

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -4,8 +4,10 @@ import ListByTab from '@/features/my-page/list-by-tab';
 import TabButtons from '@/features/my-page/tab-buttons';
 import { INIT_TAB_COUNTS } from '@/constants/my-page-constants';
 import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
+import { RESUME_STATUS } from '@/constants/resume-constants';
 
 const { COMPLETED } = INTERVIEW_HISTORY_STATUS;
+const { SUBMIT } = RESUME_STATUS;
 type Props = {
   userId: User['id'];
 };
@@ -15,7 +17,11 @@ const TabsField = async ({ userId }: Props) => {
     select: {
       _count: {
         select: {
-          resumes: true,
+          resumes: {
+            where: {
+              status: SUBMIT,
+            },
+          },
           interviewHistories: {
             where: {
               status: COMPLETED,

--- a/src/features/resume/hooks/use-delete-resume-mutation.ts
+++ b/src/features/resume/hooks/use-delete-resume-mutation.ts
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { PATH } from '@/constants/path-constant';
 
 const { MY_PAGE } = PATH;
-const { RESUMES } = QUERY_KEY;
+const { RESUMES, TABS_COUNT } = QUERY_KEY;
 
 export const useDeleteResumeMutation = (queryKey: string) => {
   const queryClient = useQueryClient();
@@ -32,6 +32,7 @@ export const useDeleteResumeMutation = (queryKey: string) => {
     },
     onSuccess: () => {
       if (queryKey === RESUMES) {
+        queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
         router.replace(MY_PAGE);
       }
     },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { getToken } from 'next-auth/jwt';
 import { NextRequest, NextResponse } from 'next/server';
-import { PATH, QUERY_PARAMS } from './constants/path-constant';
+import { PATH, QUERY_PARAMS } from '@/constants/path-constant';
 
 const {
   AUTH: { SIGN_IN },
@@ -27,5 +27,5 @@ export const middleware = async (request: NextRequest) => {
 };
 
 export const config = {
-  matcher: ['/my-page', '/resume/:path*', '/job', '/auth/sign-in', '/interview/start', '/interview/live/:path*'],
+  matcher: ['/auth/sign-in', '/interview/live/:path*'],
 };


### PR DESCRIPTION
## 💡 관련이슈

- #191 

## 🍀 작업 요약

-마이 페이지 > 자소서 삭제 후 tab count가 반영되지 않아 해당 부분 수정했습니다.

## 💬 리뷰 요구 사항

-자소서 삭제 및 추가 후 tab count가 잘 반영되는지 확인 부탁드립니다.

## 💛 미리보기

> 사진이나 gif 등 미리 볼 수 있는 파일을 제공해주세요.

### ✔️ 이슈 닫기

Closes #191 
Ref #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝나지 않은 경우


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 마이페이지의 이력서 탭에서 제출된 이력서만 개수에 포함되도록 변경되었습니다.
  - 이력서 삭제 시 탭 카운트 정보가 즉시 갱신되도록 개선되었습니다.

- **리팩터**
  - 미들웨어가 적용되는 경로가 일부 축소되었습니다. (이제 '/auth/sign-in'과 '/interview/live/:path*'만 해당)
  - 내부 주석 및 경로 import 방식이 정리되었습니다.
  - 내비게이션 바의 그림자 스타일이 인라인에서 CSS 클래스 방식으로 변경되었습니다.
  - 불필요한 주석 코드가 제거되고, 경로 접근 제어 로직이 개선되었습니다.

- **신규 기능**
  - 공용 페이지 경로 목록이 추가되어, 특정 경로에서의 내비게이션 동작이 개선되었습니다.
  - 글로벌 스타일에 다중 그림자 효과를 가진 내비게이션 그림자 클래스와 텍스트 밸런싱 스타일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->