### PR TITLE
style:#194 전체 스타일 적용 및 중복 main 태그 제거

### DIFF
--- a/src/app/(with-nav)/(with-header)/interview/start/page.tsx
+++ b/src/app/(with-nav)/(with-header)/interview/start/page.tsx
@@ -18,7 +18,7 @@ const InterviewStartPage = async () => {
   });
 
   return (
-    <main className='px-12 py-8'>
+    <div className='px-12 py-8'>
       <article className='mb-8'>
         <section className='mb-4 flex flex-row'>
           <Typography as='h2' size='2xl' weight='bold'>
@@ -39,7 +39,7 @@ const InterviewStartPage = async () => {
           <ResumeCardsBox />
         </HydrationBoundary>
       </article>
-    </main>
+    </div>
   );
 };
 

--- a/src/app/(with-nav)/(with-header)/interview/start/page.tsx
+++ b/src/app/(with-nav)/(with-header)/interview/start/page.tsx
@@ -18,7 +18,7 @@ const InterviewStartPage = async () => {
   });
 
   return (
-    <div className='px-12 py-8'>
+    <>
       <article className='mb-8'>
         <section className='mb-4 flex flex-row'>
           <Typography as='h2' size='2xl' weight='bold'>
@@ -39,7 +39,7 @@ const InterviewStartPage = async () => {
           <ResumeCardsBox />
         </HydrationBoundary>
       </article>
-    </div>
+    </>
   );
 };
 

--- a/src/app/(with-nav)/(with-header)/job/page.tsx
+++ b/src/app/(with-nav)/(with-header)/job/page.tsx
@@ -10,25 +10,21 @@ const JobPage = async () => {
   const session = await getServerSession(authOptions);
 
   return (
-    <main className='px-12 py-8 flex-grow'>
-      <section className='mb-4 flex justify-between'>
-        <div>
-          <Typography color='primary-600' as='h1' size='3xl' weight='bold'>
-            맞춤형
-            <span className='text-cool-gray-900'> 채용공고</span>
-          </Typography>
-          <Typography color='gray-500' size='xl'>
-            프로필에 작성된 정보를 통해 맞춤형 채용공고를 추천해드립니다
-          </Typography>
-        </div>
-        <div>
-          <Button link href={SARAMIN_URL} target='_blank'>
-            데이터 출처: 취업 사람인
-          </Button>
-        </div>
+    <div className='px-12 py-8'>
+      <section className='mb-4'>
+        <Typography color='primary-600' as='h1' size='3xl' weight='bold'>
+          맞춤형
+          <span className='text-cool-gray-900'> 채용공고</span>
+        </Typography>
+        <Typography color='gray-500' size='xl'>
+          프로필에 작성된 정보를 통해 맞춤형 채용공고를 추천해드립니다
+        </Typography>
       </section>
-      <JobPostingSection session={session} />
-    </main>
+
+      <Button link href={SARAMIN_URL} target='_blank'>
+        데이터 출처: 취업 사람인
+      </Button>
+    </div>
   );
 };
 

--- a/src/app/(with-nav)/(with-header)/job/page.tsx
+++ b/src/app/(with-nav)/(with-header)/job/page.tsx
@@ -20,10 +20,13 @@ const JobPage = async () => {
           프로필에 작성된 정보를 통해 맞춤형 채용공고를 추천해드립니다
         </Typography>
       </section>
+      <div className='text-right'>
+        <Button link href={SARAMIN_URL} target='_blank'>
+          데이터 출처: 취업 사람인
+        </Button>
+      </div>
 
-      <Button link href={SARAMIN_URL} target='_blank'>
-        데이터 출처: 취업 사람인
-      </Button>
+      <JobPostingSection session={session} />
     </div>
   );
 };

--- a/src/app/(with-nav)/(with-header)/job/page.tsx
+++ b/src/app/(with-nav)/(with-header)/job/page.tsx
@@ -10,7 +10,7 @@ const JobPage = async () => {
   const session = await getServerSession(authOptions);
 
   return (
-    <div className='px-12 py-8'>
+    <div className='flex h-full flex-col'>
       <section className='mb-4'>
         <Typography color='primary-600' as='h1' size='3xl' weight='bold'>
           맞춤형

--- a/src/app/(with-nav)/(with-header)/layout.tsx
+++ b/src/app/(with-nav)/(with-header)/layout.tsx
@@ -4,7 +4,7 @@ const HeaderLayout = async ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <Header />
-      <main className='mx-auto max-w-[1440px]'>{children}</main>
+      <main className='max-w-screen-desktop mx-auto px-12 pb-8 pt-28'>{children}</main>
     </>
   );
 };

--- a/src/app/(with-nav)/(with-header)/layout.tsx
+++ b/src/app/(with-nav)/(with-header)/layout.tsx
@@ -4,7 +4,7 @@ const HeaderLayout = async ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <Header />
-      <main className='max-w-screen-desktop mx-auto px-12 pb-8 pt-28'>{children}</main>
+      <main className='mx-auto h-full max-w-screen-desktop px-12 pb-8 pt-28'>{children}</main>
     </>
   );
 };

--- a/src/app/(with-nav)/(with-header)/layout.tsx
+++ b/src/app/(with-nav)/(with-header)/layout.tsx
@@ -4,7 +4,7 @@ const HeaderLayout = async ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <Header />
-      <main className='mx-auto h-full max-w-screen-desktop px-12 pb-8 pt-28'>{children}</main>
+      <main className='max-w-screen-desktop mx-auto h-full min-h-screen px-12 pb-8 pt-28'>{children}</main>
     </>
   );
 };

--- a/src/app/(with-nav)/(with-header)/resume/page.tsx
+++ b/src/app/(with-nav)/(with-header)/resume/page.tsx
@@ -24,14 +24,14 @@ const ResumePage = async () => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <main className='flex w-full gap-4 px-[50px] py-8'>
+      <div className='flex w-full gap-4 px-[50px] py-8'>
         <section className='mx-auto flex w-full max-w-[786px] flex-col gap-4'>
           <Typography as='h2' size='2xl' weight='bold'>
             <span className='text-primary-orange-600'>자소서</span>를 작성 해 볼까요?
           </Typography>
           <ResumeForm />
         </section>
-      </main>
+      </div>
     </HydrationBoundary>
   );
 };

--- a/src/app/(with-nav)/(with-header)/resume/page.tsx
+++ b/src/app/(with-nav)/(with-header)/resume/page.tsx
@@ -24,14 +24,12 @@ const ResumePage = async () => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <div className='flex w-full gap-4 px-[50px] py-8'>
-        <section className='mx-auto flex w-full max-w-[786px] flex-col gap-4'>
-          <Typography as='h2' size='2xl' weight='bold'>
-            <span className='text-primary-orange-600'>자소서</span>를 작성 해 볼까요?
-          </Typography>
-          <ResumeForm />
-        </section>
-      </div>
+      <section className='mx-auto flex w-full max-w-[853px] flex-col gap-4'>
+        <Typography as='h2' size='2xl' weight='bold'>
+          <span className='text-primary-orange-600'>자소서</span>를 작성 해 볼까요?
+        </Typography>
+        <ResumeForm />
+      </section>
     </HydrationBoundary>
   );
 };

--- a/src/components/common/block-component.tsx
+++ b/src/components/common/block-component.tsx
@@ -12,7 +12,7 @@ type Props = {
   onClick?: () => void;
 };
 
-const defaultClassName = 'w-full flex flex-col justify-center items-center gap-4';
+const defaultClassName = 'w-full flex flex-col justify-center items-center gap-4 h-full';
 
 const BlockComponent = (props: Props) => {
   const { className, firstLine, secondLine, thirdLine, buttonName, href, onClick } = props;

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -49,7 +49,7 @@ const Modal = ({ portalRoot, modalId, children, className }: Props) => {
   }, [toggleModal, modalId]);
 
   return createPortal(
-    <div className='fixed inset-0 z-50 flex items-center justify-center overflow-y-auto'>
+    <div className='z-modal fixed inset-0 flex items-center justify-center overflow-y-auto'>
       <div className='fixed inset-0 bg-black opacity-70' />
       <div
         ref={modalContentRef}

--- a/src/components/ui/screen-overlay.tsx
+++ b/src/components/ui/screen-overlay.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 const ScreenOverlay = ({ children }: Props) => {
   return (
-    <div className='absolute inset-0 z-10 flex items-center justify-center bg-white/40 backdrop-blur-sm'>
+    <div className='z-overlay absolute inset-0 flex items-center justify-center bg-white/40 backdrop-blur-sm'>
       {children}
     </div>
   );

--- a/src/features/interview-history/interview-detail-history.tsx
+++ b/src/features/interview-history/interview-detail-history.tsx
@@ -14,7 +14,7 @@ const InterviewDetailHistory = ({ data }: Props) => {
   const history = data.InterviewQnAList;
   return (
     <section className='relative flex-1 overflow-hidden'>
-      <div className='pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-10 bg-gradient-to-t from-white to-transparent' />
+      <div className='z-overlay pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent' />
 
       <ol className='flex h-full flex-col gap-4 overflow-y-auto pr-2 scrollbar-hide'>
         {history.map((interviewQna, idx) => (

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -36,7 +36,7 @@ const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
   }, []);
 
   return (
-    <main className='flex flex-col gap-8 px-[50px] py-8'>
+    <div className='flex flex-col gap-8 px-[50px] py-8'>
       <section className='flex w-full flex-col gap-4'>
         <div className='flex items-center justify-between'>
           <Typography size='2xl' weight='bold'>
@@ -50,7 +50,7 @@ const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
         </div>
       </section>
       <QuestionDisplayWithTimer interviewHistory={interviewHistory} interviewQnAList={interviewQnAList} />
-    </main>
+    </div>
   );
 };
 

--- a/src/features/job/job-posting-block-component.tsx
+++ b/src/features/job/job-posting-block-component.tsx
@@ -43,16 +43,12 @@ export const JobPostingBlockComponent = ({ type }: Props) => {
       buttonName: '채용공고 불러오기!',
       onClick: () => router.refresh(),
     },
-    'no-bookmark' : {
+    'no-bookmark': {
       firstLine: '이런! 북마크한 채용 공고가 없어요!',
       secondLine: '내 맘에 쏙 든 채용 공고를 북마크 해볼까요?',
       thirdLine: '맞춤형 채용공고는 내 정보를 기반으로 진행됩니다.',
-    }
+    },
   }[type];
 
-  return (
-    <section className='flex h-[400px] flex-col items-center justify-center self-stretch'>
-      <BlockComponent {...content} />
-    </section>
-  );
+  return <BlockComponent {...content} />;
 };

--- a/src/features/job/job-posting-pagination-button.tsx
+++ b/src/features/job/job-posting-pagination-button.tsx
@@ -33,7 +33,7 @@ const JobPostingPaginationButton = ({ totalCount, page, setPage }: Props) => {
   return (
     <>
       {totalPageCount > MIN_PAGE_COUNT && (
-        <div className='mt-6 flex flex-wrap justify-center gap-2'>
+        <div className='flex flex-wrap items-center justify-center gap-2 py-8'>
           {startPage > 1 && (
             <button onClick={() => goToPage(startPage - 1)} className='rounded border text-sm'>
               <LeftArrowIcon />

--- a/src/features/job/job-posting-section.tsx
+++ b/src/features/job/job-posting-section.tsx
@@ -11,7 +11,7 @@ const JobPostingSection = async ({ session }: Props) => {
     return <JobPostingBlockComponent type='unauthenticated' />;
   }
   return (
-    <article>
+    <article className='h-full'>
       <JobPostingsBox userId={session.user.id} />
     </article>
   );

--- a/src/features/job/job-postings-box.tsx
+++ b/src/features/job/job-postings-box.tsx
@@ -80,15 +80,14 @@ const JobPostingsBox = ({ userId }: Props) => {
     }
 
     return (
-      <div className='flex flex-col items-center justify-between gap-6'>
-        <section className='flex flex-wrap gap-5 self-stretch scrollbar-hide'>
+      <>
+        <div className='flex flex-wrap justify-between gap-2'>
           {data.jobPostingList.map((jobPosting) => (
             <JobPostingCard key={jobPosting.id} userId={userId} jobPosting={jobPosting} />
           ))}
-        </section>
-
+        </div>
         <JobPostingPaginationButton totalCount={data.totalCount} page={page} setPage={setPage} />
-      </div>
+      </>
     );
   };
 

--- a/src/features/layout/header.tsx
+++ b/src/features/layout/header.tsx
@@ -7,7 +7,7 @@ export const Header = async () => {
   const session = await getServerSession(authOptions);
 
   return (
-    <header className='flex items-center justify-between border-b border-cool-gray-500 bg-white py-4'>
+    <header className='z-modal fixed flex h-20 w-[calc(100vw-52px)] items-center justify-between border-b border-cool-gray-500 bg-white py-4'>
       <HeaderTitle />
       <HeaderCharacter session={session} />
     </header>

--- a/src/features/layout/nav.tsx
+++ b/src/features/layout/nav.tsx
@@ -28,7 +28,7 @@ export const Nav = ({ session }: Props) => {
         {menus.map((menu) => (
           <li key={`menu_${menu.name}`} className={clsx('group relative', menu.class)}>
             {menu.type === 'link' ? <LinkNav menu={menu} /> : <ButtonNav menu={menu} />}
-            <span className='absolute left-full top-1/2 z-10 ml-4 hidden -translate-y-1/2 whitespace-nowrap rounded-md bg-cool-gray-900 px-2 py-1 text-sm text-white opacity-0 shadow-md transition-opacity duration-300 group-hover:inline group-hover:opacity-100'>
+            <span className='z-overlay absolute left-full top-1/2 ml-4 hidden -translate-y-1/2 whitespace-nowrap rounded-md bg-cool-gray-900 px-2 py-1 text-sm text-white opacity-0 shadow-md transition-opacity duration-300 group-hover:inline group-hover:opacity-100'>
               {menu.name}
             </span>
           </li>

--- a/src/features/resume/resume-form-action-button.tsx
+++ b/src/features/resume/resume-form-action-button.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const ResumeFormActionButton = ({ resume, draftResumeList, autoSaveStatus, onClick }: Props) => {
   return (
-    <div className='flex justify-between'>
+    <div className='mb-8 flex justify-between'>
       {resume ? (
         <Button variant='outline' color='dark' size='large' type='submit'>
           수정 완료

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,11 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        'desktop': '1728px',
+        'tablet': '', //@미정
+        'mobile': '', //@미정
+      },
       colors: {
         'primary-orange': {
           600: '#E55A27',
@@ -40,6 +45,11 @@ const config: Config = {
         'rounded-2xl': '1rem',
         'rounded-3xl': '1.5rem',
         'rounded-full': '50%',
+      },
+      zIndex: {
+        modal: '100',
+        header: '90',
+        overlay: '10',
       },
     },
   },


### PR DESCRIPTION
## 💡 관련이슈

- #194 

## 🍀 작업 요약

- header 고정
- main 영역 기본 padding 적용
- main 안에 main 구조 수정
- z-index 상수화
- break points 정의 ( -> tablet, mobile은 아직 미정 )

## 💬 리뷰 요구 사항

- 불필요한 스크롤이 생기지 않는지 확인 부탁드립니다!

## 💛 미리보기

> 사진이나 gif 등 미리 볼 수 있는 파일을 제공해주세요.

### ✔️ 이슈 닫기

Closes #194 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
    - 여러 페이지 및 컴포넌트에서 z-index 관련 Tailwind CSS 클래스를 의미 있는 이름(z-modal, z-overlay 등)으로 변경하여 레이어링 일관성 개선
    - 일부 페이지의 최상위 컨테이너를 `<main>`에서 `<div>` 또는 React fragment로 변경하여 시맨틱 구조 조정 및 중첩 제거
    - Header의 위치와 크기, z-index 스타일 조정으로 고정 헤더 동작 및 레이아웃 개선
    - 레이아웃의 최대 너비 및 패딩 스타일을 조정하여 반응형 디자인 개선
    - 네비게이션 툴팁의 z-index 클래스 변경으로 레이어링 개선
    - 오류 UI 감싸는 섹션 제거 및 일부 컴포넌트 높이 스타일 조정
    - 버튼 및 컨테이너의 여백과 정렬 스타일 개선
    - 구직 게시물 및 인터뷰 관련 컴포넌트의 레이아웃 및 스타일 조정

- **Chores**
    - Tailwind CSS 설정에 커스텀 반응형 브레이크포인트(desktop 등)와 의미 기반 z-index 값(modal, header, overlay 등) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->