### PR TITLE
Feature/#188 면접 이어하기

### DIFF
--- a/src/app/(with-nav)/(with-header)/interview/live/[id]/page.tsx
+++ b/src/app/(with-nav)/(with-header)/interview/live/[id]/page.tsx
@@ -1,13 +1,10 @@
 import { Metadata } from 'next';
 import { getServerSession } from 'next-auth';
-import Typography from '@/components/ui/typography';
 import { authOptions } from '@/utils/auth-option';
-import CameraView from '@/features/interview/camera-view';
 import { getInterviewHistory, getInterviewQnA } from '@/features/interview/api/server-services';
-import QuestionDisplayWithTimer from '@/features/interview/question-display-with-timer';
-import QuestionStep from '@/features/interview/question-step';
 import type { RouteParams } from '@/types/route-params';
 import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
+import InterviewClient from '@/features/interview/interview-client';
 
 export const metadata: Metadata = {
   title: 'AI 면접',
@@ -18,7 +15,7 @@ const InterviewPage = async ({ params }: RouteParams) => {
   const session = await getServerSession(authOptions);
   const interviewId = Number(params.id);
   const interviewHistory = await getInterviewHistory(interviewId);
-  const interviewQnA = await getInterviewQnA(interviewId);
+  const interviewQnAList = await getInterviewQnA(interviewId);
 
   if (!session || !interviewHistory) return null;
 
@@ -26,23 +23,7 @@ const InterviewPage = async ({ params }: RouteParams) => {
     return <div>이미 완료된 면접입니다.</div>;
   }
 
-  return (
-    <main className='flex flex-col gap-8 px-[50px] py-8'>
-      <section className='flex w-full flex-col gap-4'>
-        <div className='flex items-center justify-between'>
-          <Typography size='2xl' weight='bold'>
-            집중하세요! <span className='text-primary-orange-600'>면접이 시작됐습니다</span>
-          </Typography>
-          <QuestionStep />
-        </div>
-        <div className='flex h-[335px] gap-5'>
-          <div className='flex-1 rounded-lg border border-cool-gray-200 bg-white'>면접관</div>
-          <CameraView />
-        </div>
-      </section>
-      <QuestionDisplayWithTimer interviewHistory={interviewHistory} />
-    </main>
-  );
+  return <InterviewClient interviewHistory={interviewHistory} interviewQnAList={interviewQnAList} />;
 };
 
 export default InterviewPage;

--- a/src/app/(with-nav)/(with-header)/interview/live/[id]/page.tsx
+++ b/src/app/(with-nav)/(with-header)/interview/live/[id]/page.tsx
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth';
 import Typography from '@/components/ui/typography';
 import { authOptions } from '@/utils/auth-option';
 import CameraView from '@/features/interview/camera-view';
-import { getInterviewHistory } from '@/features/interview/api/server-services';
+import { getInterviewHistory, getInterviewQnA } from '@/features/interview/api/server-services';
 import QuestionDisplayWithTimer from '@/features/interview/question-display-with-timer';
 import QuestionStep from '@/features/interview/question-step';
 import type { RouteParams } from '@/types/route-params';
@@ -18,6 +18,7 @@ const InterviewPage = async ({ params }: RouteParams) => {
   const session = await getServerSession(authOptions);
   const interviewId = Number(params.id);
   const interviewHistory = await getInterviewHistory(interviewId);
+  const interviewQnA = await getInterviewQnA(interviewId);
 
   if (!session || !interviewHistory) return null;
 

--- a/src/app/api/ai/interview/[id]/route.ts
+++ b/src/app/api/ai/interview/[id]/route.ts
@@ -87,7 +87,7 @@ export const POST = async (request: NextRequest, { params }: RouteParams) => {
     await prisma.interviewQnA.create({
       data: {
         interviewHistoryId: response.id,
-        question: '자기소개를 해주세요.',
+        question: '면접 준비가 완료되었다면, 말하기 버튼을 눌러 자기 소개를 해주세요.',
       },
     });
 

--- a/src/app/api/ai/interview/[id]/route.ts
+++ b/src/app/api/ai/interview/[id]/route.ts
@@ -100,6 +100,7 @@ export const POST = async (request: NextRequest, { params }: RouteParams) => {
 /**
  * 인터뷰 기록 status 변경하는 요청
  * @param interviewId 인터뷰 기록 ID
+ * @param status 인터뷰 기록 상태
  * @returns interviewHistory 업데이트된 인터뷰 기록
  */
 export const PATCH = async (request: NextRequest, { params }: RouteParams) => {
@@ -113,6 +114,7 @@ export const PATCH = async (request: NextRequest, { params }: RouteParams) => {
     }
 
     const interviewId = Number(params.id);
+    const { status } = await request.json();
 
     const interviewHistory = await prisma.interviewHistory.findUnique({
       where: { id: interviewId },
@@ -130,7 +132,7 @@ export const PATCH = async (request: NextRequest, { params }: RouteParams) => {
       where: { id: interviewId },
       data: {
         userId: session.user.id,
-        status: INTERVIEW_HISTORY_STATUS.COMPLETED,
+        status,
       },
     });
 

--- a/src/constants/interview-constants.ts
+++ b/src/constants/interview-constants.ts
@@ -13,4 +13,5 @@ export const INTERVIEW_LIMIT_COUNT = 8;
 export const INTERVIEW_HISTORY_STATUS = {
   PENDING: 0,
   COMPLETED: 1,
+  IN_PROGRESS: 2,
 };

--- a/src/features/interview/api/client-services.ts
+++ b/src/features/interview/api/client-services.ts
@@ -116,11 +116,19 @@ export const postInterview = async ({ resumeId, interviewType }: InterviewProps)
 
 /** DB에 인터뷰 기록 업데이트하는 요청
  * @param interviewId 인터뷰 기록 ID
+ * @param status 업데이트하고자하는 상태
  */
+type InterviewHistoryProps = {
+  interviewId: number;
+  status: number;
+};
 
-export const patchInterviewHistoryStatus = async (interviewId: number) => {
+export const patchInterviewHistoryStatus = async ({ interviewId, status }: InterviewHistoryProps) => {
   await fetchWithSentry(INTERVIEW_LIVE(interviewId), {
     method: PATCH,
+    body: JSON.stringify({
+      status,
+    }),
     headers: JSON_HEADER,
   });
 };

--- a/src/features/interview/api/server-services.ts
+++ b/src/features/interview/api/server-services.ts
@@ -31,3 +31,33 @@ export const getInterviewHistory = async (interviewId: number) => {
     throw new Error(GET_ERROR);
   }
 };
+
+/**
+ *
+ * @param interviewId
+ * @returns data ID에 해당하는 QnA 기록
+ */
+export const getInterviewQnA = async (interviewId: number) => {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      throw new Error(AUTH_REQUIRED);
+    }
+
+    const response = await prisma.interviewQnA.findMany({
+      where: {
+        interviewHistoryId: interviewId,
+        interviewHistory: {
+          userId: session.user.id,
+        },
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+
+    return response;
+  } catch (error) {
+    throw new Error(GET_ERROR);
+  }
+};

--- a/src/features/interview/hooks/use-interview-history-mutation.ts
+++ b/src/features/interview/hooks/use-interview-history-mutation.ts
@@ -2,6 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QUERY_KEY } from '@/constants/query-key';
 import { patchInterviewHistoryStatus } from '@/features/interview/api/client-services';
 
+const { HISTORY } = QUERY_KEY;
+
 export const usePatchInterviewHistoryMutation = () => {
   const queryClient = useQueryClient();
 
@@ -9,7 +11,7 @@ export const usePatchInterviewHistoryMutation = () => {
     mutationFn: ({ interviewId, status }: { interviewId: number; status: number }) =>
       patchInterviewHistoryStatus({ interviewId, status }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.HISTORY] });
+      queryClient.invalidateQueries({ queryKey: [HISTORY] });
     },
     onError: (error) => {
       throw error;

--- a/src/features/interview/hooks/use-interview-history-mutation.ts
+++ b/src/features/interview/hooks/use-interview-history-mutation.ts
@@ -6,7 +6,8 @@ export const usePatchInterviewHistoryMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (interviewId: number) => patchInterviewHistoryStatus(interviewId),
+    mutationFn: ({ interviewId, status }: { interviewId: number; status: number }) =>
+      patchInterviewHistoryStatus({ interviewId, status }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.HISTORY] });
     },

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Typography from '@/components/ui/typography';
+import { InterviewHistoryType } from '@/types/DTO/interview-history-dto';
+import { InterviewQnAType } from '@/types/DTO/interview-qna-dto';
+import QuestionStep from '@/features/interview/question-step';
+import CameraView from '@/features/interview/camera-view';
+import QuestionDisplayWithTimer from '@/features/interview/question-display-with-timer';
+import { useEffect } from 'react';
+import { useInterviewStore } from '@/store/use-interview-store';
+
+type Props = {
+  interviewHistory: InterviewHistoryType;
+  interviewQnAList: InterviewQnAType[];
+};
+
+const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
+  const setQuestionIndex = useInterviewStore((state) => state.setQuestionIndex);
+  useEffect(() => {
+    setQuestionIndex(interviewQnAList.length - 1);
+  }, []);
+  return (
+    <main className='flex flex-col gap-8 px-[50px] py-8'>
+      <section className='flex w-full flex-col gap-4'>
+        <div className='flex items-center justify-between'>
+          <Typography size='2xl' weight='bold'>
+            집중하세요! <span className='text-primary-orange-600'>면접이 시작됐습니다</span>
+          </Typography>
+          <QuestionStep />
+        </div>
+        <div className='flex h-[335px] gap-5'>
+          <div className='flex-1 rounded-lg border border-cool-gray-200 bg-white'>면접관</div>
+          <CameraView />
+        </div>
+      </section>
+      <QuestionDisplayWithTimer interviewHistory={interviewHistory} />
+    </main>
+  );
+};
+
+export default InterviewClient;

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -6,8 +6,14 @@ import { InterviewQnAType } from '@/types/DTO/interview-qna-dto';
 import QuestionStep from '@/features/interview/question-step';
 import CameraView from '@/features/interview/camera-view';
 import QuestionDisplayWithTimer from '@/features/interview/question-display-with-timer';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useInterviewStore } from '@/store/use-interview-store';
+import { patchInterviewHistoryStatus } from './api/client-services';
+import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
+
+const { IN_PROGRESS } = INTERVIEW_HISTORY_STATUS;
+const LAST_QNA_INDEX = -1;
+const CHECK_LEAST_INDEX = 1;
 
 type Props = {
   interviewHistory: InterviewHistoryType;
@@ -15,10 +21,20 @@ type Props = {
 };
 
 const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
+  const [lastQnA, setLastQnA] = useState<InterviewQnAType | null>(null);
   const setQuestionIndex = useInterviewStore((state) => state.setQuestionIndex);
+
   useEffect(() => {
-    setQuestionIndex(interviewQnAList.length - 1);
+    setQuestionIndex(interviewQnAList.length - CHECK_LEAST_INDEX);
+
+    if (interviewQnAList.length > CHECK_LEAST_INDEX) {
+      setLastQnA(interviewQnAList.at(LAST_QNA_INDEX) || null);
+    }
+    return () => {
+      patchInterviewHistoryStatus({ interviewId: interviewHistory.id, status: IN_PROGRESS });
+    };
   }, []);
+
   return (
     <main className='flex flex-col gap-8 px-[50px] py-8'>
       <section className='flex w-full flex-col gap-4'>
@@ -33,7 +49,7 @@ const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
           <CameraView />
         </div>
       </section>
-      <QuestionDisplayWithTimer interviewHistory={interviewHistory} />
+      <QuestionDisplayWithTimer interviewHistory={interviewHistory} interviewLastQnA={lastQnA} />
     </main>
   );
 };

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -49,7 +49,7 @@ const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
           <CameraView />
         </div>
       </section>
-      <QuestionDisplayWithTimer interviewHistory={interviewHistory} interviewLastQnA={lastQnA} />
+      <QuestionDisplayWithTimer interviewHistory={interviewHistory} interviewQnAList={interviewQnAList} />
     </main>
   );
 };

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -8,7 +8,7 @@ import CameraView from '@/features/interview/camera-view';
 import QuestionDisplayWithTimer from '@/features/interview/question-display-with-timer';
 import { useEffect, useState } from 'react';
 import { useInterviewStore } from '@/store/use-interview-store';
-import { patchInterviewHistoryStatus } from './api/client-services';
+import { patchInterviewHistoryStatus } from '@/features/interview/api/client-services';
 import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
 
 const { IN_PROGRESS } = INTERVIEW_HISTORY_STATUS;

--- a/src/features/interview/question-display-with-timer.tsx
+++ b/src/features/interview/question-display-with-timer.tsx
@@ -21,7 +21,11 @@ const QuestionDisplayWithTimer = ({ interviewHistory, interviewLastQnA }: Props)
     useAudioWithTimer({ duration: MINUTES_IN_MS, interviewHistory });
 
   if (!interviewLastQnA && interviewHistory.status === IN_PROGRESS) {
-    return <LoadingSpinner />;
+    return (
+      <section className='mt-20 flex items-center justify-center'>
+        <LoadingSpinner />
+      </section>
+    );
   }
   return (
     <section className='flex gap-5'>

--- a/src/features/interview/question-display-with-timer.tsx
+++ b/src/features/interview/question-display-with-timer.tsx
@@ -2,13 +2,13 @@
 
 import Timer from '@/features/interview/timer';
 import { useAudioWithTimer } from '@/features/interview/hooks/use-audio-with-timer';
-import QuestionDisplay from './question-display';
-import { InterviewHistory } from '@prisma/client';
+import QuestionDisplay from '@/features/interview/question-display';
+import { InterviewHistoryType } from '@/types/DTO/interview-history-dto';
 
 const MINUTES_IN_MS = 1 * 60 * 1000;
 
 type Props = {
-  interviewHistory: InterviewHistory;
+  interviewHistory: InterviewHistoryType;
 };
 
 const QuestionDisplayWithTimer = ({ interviewHistory }: Props) => {

--- a/src/features/interview/question-display-with-timer.tsx
+++ b/src/features/interview/question-display-with-timer.tsx
@@ -4,22 +4,34 @@ import Timer from '@/features/interview/timer';
 import { useAudioWithTimer } from '@/features/interview/hooks/use-audio-with-timer';
 import QuestionDisplay from '@/features/interview/question-display';
 import { InterviewHistoryType } from '@/types/DTO/interview-history-dto';
+import { InterviewQnAType } from '@/types/DTO/interview-qna-dto';
+import LoadingSpinner from '@/components/ui/loading-spinner';
+import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
 
 const MINUTES_IN_MS = 1 * 60 * 1000;
+const { IN_PROGRESS } = INTERVIEW_HISTORY_STATUS;
 
 type Props = {
   interviewHistory: InterviewHistoryType;
+  interviewLastQnA: InterviewQnAType | null;
 };
 
-const QuestionDisplayWithTimer = ({ interviewHistory }: Props) => {
+const QuestionDisplayWithTimer = ({ interviewHistory, interviewLastQnA }: Props) => {
   const { isRecording, isAIVoicePlaying, formattedTime, aiQuestion, startRecordingWithTimer, stopRecordingWithTimer } =
     useAudioWithTimer({ duration: MINUTES_IN_MS, interviewHistory });
 
+  if (!interviewLastQnA && interviewHistory.status === IN_PROGRESS) {
+    return <LoadingSpinner />;
+  }
   return (
     <section className='flex gap-5'>
       <QuestionDisplay
         interviewHistory={interviewHistory}
-        aiQuestion={aiQuestion || '면접 준비가 완료되었다면, 말하기 버튼을 눌러 자기 소개를 해주세요.'}
+        aiQuestion={
+          aiQuestion ||
+          interviewLastQnA?.question ||
+          '면접 준비가 완료되었다면, 말하기 버튼을 눌러 자기 소개를 해주세요.'
+        }
       />
       <Timer
         interviewHistory={interviewHistory}

--- a/src/features/interview/question-display-with-timer.tsx
+++ b/src/features/interview/question-display-with-timer.tsx
@@ -13,14 +13,14 @@ const { IN_PROGRESS } = INTERVIEW_HISTORY_STATUS;
 
 type Props = {
   interviewHistory: InterviewHistoryType;
-  interviewLastQnA: InterviewQnAType | null;
+  interviewQnAList: InterviewQnAType[];
 };
 
-const QuestionDisplayWithTimer = ({ interviewHistory, interviewLastQnA }: Props) => {
+const QuestionDisplayWithTimer = ({ interviewHistory, interviewQnAList }: Props) => {
   const { isRecording, isAIVoicePlaying, formattedTime, aiQuestion, startRecordingWithTimer, stopRecordingWithTimer } =
     useAudioWithTimer({ duration: MINUTES_IN_MS, interviewHistory });
 
-  if (!interviewLastQnA && interviewHistory.status === IN_PROGRESS) {
+  if (!interviewQnAList && interviewHistory.status === IN_PROGRESS) {
     return (
       <section className='mt-20 flex items-center justify-center'>
         <LoadingSpinner />
@@ -33,7 +33,7 @@ const QuestionDisplayWithTimer = ({ interviewHistory, interviewLastQnA }: Props)
         interviewHistory={interviewHistory}
         aiQuestion={
           aiQuestion ||
-          interviewLastQnA?.question ||
+          interviewQnAList.at(-1)?.question ||
           '면접 준비가 완료되었다면, 말하기 버튼을 눌러 자기 소개를 해주세요.'
         }
       />

--- a/src/features/interview/question-display.tsx
+++ b/src/features/interview/question-display.tsx
@@ -2,18 +2,18 @@ import Image from 'next/image';
 import Typography from '@/components/ui/typography';
 import { INTERVIEW_LIMIT_COUNT, INTERVIEW_TYPE, INTERVIEW_TYPE_KR } from '@/constants/interview-constants';
 import { useInterviewStore } from '@/store/use-interview-store';
-import type { InterviewHistory } from '@prisma/client';
+import { InterviewHistoryType } from '@/types/DTO/interview-history-dto';
 
 const { CALM } = INTERVIEW_TYPE;
 const { CALM_KR, PRESSURE_KR } = INTERVIEW_TYPE_KR;
 
 type Props = {
-  interviewHistory: InterviewHistory;
+  interviewHistory: InterviewHistoryType;
   aiQuestion: string;
 };
 
 const QuestionDisplay = ({ interviewHistory, aiQuestion }: Props) => {
-  const { interviewType } = interviewHistory;
+  const { interviewType, id } = interviewHistory;
 
   const interviewImage = interviewType === CALM ? 2 : 3; // TODO: 면접관 이미지 확정되면 수정
   const isInterviewTypeCalm = interviewType === CALM;

--- a/src/features/interview/timer.tsx
+++ b/src/features/interview/timer.tsx
@@ -5,7 +5,7 @@ import { useCharacterStore } from '@/store/use-character-store';
 import { useInterviewStore } from '@/store/use-interview-store';
 import Button from '@/components/ui/button';
 import Typography from '@/components/ui/typography';
-import { INTERVIEW_LIMIT_COUNT } from '@/constants/interview-constants';
+import { INTERVIEW_HISTORY_STATUS, INTERVIEW_LIMIT_COUNT } from '@/constants/interview-constants';
 import { CHARACTER_HISTORY_KEY } from '@/constants/character-constants';
 import { PATH } from '@/constants/path-constant';
 import { useExperienceUp } from '@/features/character/hooks/use-experience-up';
@@ -18,6 +18,7 @@ import { QUERY_KEY } from '@/constants/query-key';
 const { MY_PAGE } = PATH;
 const { INTERVIEW_COMPLETION } = CHARACTER_HISTORY_KEY;
 const { TABS_COUNT } = QUERY_KEY;
+const { COMPLETED } = INTERVIEW_HISTORY_STATUS;
 type Props = {
   interviewHistory: InterviewHistory;
   isRecording: boolean;
@@ -73,7 +74,7 @@ const Timer = ({
       alert('경험치 획득 완료!'); //@TODO: 경험치 정의 완료된 후에 alert 리팩토링하면서 상수로 빼겠습니다.
     }
 
-    patchInterviewHistoryMutate(interviewHistory.id);
+    patchInterviewHistoryMutate({ interviewId: interviewHistory.id, status: COMPLETED });
     postAIFeedbackMutate(interviewHistory.id);
     //여기 충돌날 거 같아요! 이부분 마이 페이지 버튼 카운팅에 필요한 부분입니다 충돌 해결이 어렵다면 저(이다혜)를 찔러주세여!
     queryClient.invalidateQueries({

--- a/src/store/use-interview-store.ts
+++ b/src/store/use-interview-store.ts
@@ -4,16 +4,19 @@ type InterviewState = {
   questionIndex: number;
   incrementQuestionIndex: () => void;
   resetQuestionIndex: () => void;
+  setQuestionIndex: (index: number) => void;
 };
 
 const initialState: InterviewState = {
   questionIndex: 0,
   incrementQuestionIndex: () => {},
   resetQuestionIndex: () => {},
+  setQuestionIndex: (index: number) => {},
 };
 
 export const useInterviewStore = create<InterviewState>((set) => ({
   questionIndex: initialState.questionIndex,
   incrementQuestionIndex: () => set((state) => ({ questionIndex: state.questionIndex + 1 })),
   resetQuestionIndex: () => set({ questionIndex: 0 }),
+  setQuestionIndex: (index: number) => set({ questionIndex: index }),
 }));


### PR DESCRIPTION
## 💡 관련이슈

- #188

## 🍀 작업 요약

- 인터뷰 상태 관리
- 인터뷰의 상태가 `IN_PROGRESS`인 인터뷰 이어가기

## 💬 리뷰 요구 사항

- `Unmounted`에 대한 코드를 집중적으로 확인해주세요!

## 💛 미리보기

![1](https://github.com/user-attachments/assets/947d31fc-ee99-4589-8fd3-50ba59479291)


### ✔️ 이슈 닫기

Ref #188 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 면접 세션 인터페이스를 관리하는 새로운 InterviewClient 컴포넌트가 추가되었습니다.
  - 면접 QnA(질문 및 답변) 목록을 조회하는 기능이 추가되었습니다.

- **개선 및 변경**
  - 면접 상태를 "진행 중"으로 업데이트할 수 있도록 상태 관리가 개선되었습니다.
  - 면접 기록 상태 변경 시, 완료 외에 다양한 상태값을 지원합니다.
  - 면접 질문 인덱스를 직접 설정할 수 있는 기능이 추가되었습니다.
  - 면접 진행 중 마지막 QnA가 없을 경우 로딩 상태가 표시됩니다.
  - 면접 페이지가 InterviewClient 컴포넌트로 단순화되어 데이터 처리와 UI가 분리되었습니다.
  - 기본 면접 질문 문구가 보다 명확한 안내 문장으로 변경되었습니다.
  - 일부 컴포넌트의 타입이 DTO 기반으로 변경되었습니다.

- **버그 수정**
  - 없음

- **기타**
  - API 요청 및 뮤테이션 함수들이 상태 파라미터를 포함하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->