### PR TITLE
Hotfix/#202 interview status

### DIFF
--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -6,13 +6,13 @@ import { InterviewQnAType } from '@/types/DTO/interview-qna-dto';
 import QuestionStep from '@/features/interview/question-step';
 import CameraView from '@/features/interview/camera-view';
 import QuestionDisplayWithTimer from '@/features/interview/question-display-with-timer';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useInterviewStore } from '@/store/use-interview-store';
 import { patchInterviewHistoryStatus } from '@/features/interview/api/client-services';
 import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
 
 const { IN_PROGRESS } = INTERVIEW_HISTORY_STATUS;
-const LAST_QNA_INDEX = -1;
+const INTERVIEW_END_INDEX = 8;
 const CHECK_LEAST_INDEX = 1;
 
 type Props = {
@@ -21,17 +21,19 @@ type Props = {
 };
 
 const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
-  const [lastQnA, setLastQnA] = useState<InterviewQnAType | null>(null);
   const setQuestionIndex = useInterviewStore((state) => state.setQuestionIndex);
+  const questionIndex = useInterviewStore((state) => state.questionIndex);
+  const latestQuestionIndex = useRef(questionIndex);
 
   useEffect(() => {
+    latestQuestionIndex.current = questionIndex;
+  }, [questionIndex]);
+  useEffect(() => {
     setQuestionIndex(interviewQnAList.length - CHECK_LEAST_INDEX);
-
-    if (interviewQnAList.length > CHECK_LEAST_INDEX) {
-      setLastQnA(interviewQnAList.at(LAST_QNA_INDEX) || null);
-    }
     return () => {
-      patchInterviewHistoryStatus({ interviewId: interviewHistory.id, status: IN_PROGRESS });
+      if (latestQuestionIndex.current < INTERVIEW_END_INDEX) {
+        patchInterviewHistoryStatus({ interviewId: interviewHistory.id, status: IN_PROGRESS });
+      }
     };
   }, []);
 

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -25,7 +25,7 @@ const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
   const setQuestionIndex = useInterviewStore((state) => state.setQuestionIndex);
   const questionIndex = useInterviewStore((state) => state.questionIndex);
   const latestQuestionIndex = useRef(questionIndex);
-  console.log(questionIndex);
+
   useEffect(() => {
     latestQuestionIndex.current = questionIndex;
   }, [questionIndex]);

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -28,6 +28,7 @@ const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
   useEffect(() => {
     latestQuestionIndex.current = questionIndex;
   }, [questionIndex]);
+
   useEffect(() => {
     setQuestionIndex(interviewQnAList.length - CHECK_LEAST_INDEX);
     return () => {

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -6,7 +6,7 @@ import { InterviewQnAType } from '@/types/DTO/interview-qna-dto';
 import QuestionStep from '@/features/interview/question-step';
 import CameraView from '@/features/interview/camera-view';
 import QuestionDisplayWithTimer from '@/features/interview/question-display-with-timer';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useInterviewStore } from '@/store/use-interview-store';
 import { patchInterviewHistoryStatus } from '@/features/interview/api/client-services';
 import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';

--- a/src/features/interview/interview-client.tsx
+++ b/src/features/interview/interview-client.tsx
@@ -9,11 +9,12 @@ import QuestionDisplayWithTimer from '@/features/interview/question-display-with
 import { useEffect, useRef } from 'react';
 import { useInterviewStore } from '@/store/use-interview-store';
 import { patchInterviewHistoryStatus } from '@/features/interview/api/client-services';
-import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
+import { INTERVIEW_HISTORY_STATUS, INTERVIEW_LIMIT_COUNT } from '@/constants/interview-constants';
 
 const { IN_PROGRESS } = INTERVIEW_HISTORY_STATUS;
-const INTERVIEW_END_INDEX = 8;
+
 const CHECK_LEAST_INDEX = 1;
+const CHECK_LAST_INDEX = -1;
 
 type Props = {
   interviewHistory: InterviewHistoryType;
@@ -24,15 +25,19 @@ const InterviewClient = ({ interviewHistory, interviewQnAList }: Props) => {
   const setQuestionIndex = useInterviewStore((state) => state.setQuestionIndex);
   const questionIndex = useInterviewStore((state) => state.questionIndex);
   const latestQuestionIndex = useRef(questionIndex);
-
+  console.log(questionIndex);
   useEffect(() => {
     latestQuestionIndex.current = questionIndex;
   }, [questionIndex]);
 
   useEffect(() => {
-    setQuestionIndex(interviewQnAList.length - CHECK_LEAST_INDEX);
+    if (interviewQnAList.length === INTERVIEW_LIMIT_COUNT && interviewQnAList.at(CHECK_LAST_INDEX)?.answer !== null) {
+      setQuestionIndex(interviewQnAList.length);
+    } else {
+      setQuestionIndex(interviewQnAList.length - CHECK_LEAST_INDEX);
+    }
     return () => {
-      if (latestQuestionIndex.current < INTERVIEW_END_INDEX) {
+      if (latestQuestionIndex.current < INTERVIEW_LIMIT_COUNT) {
         patchInterviewHistoryStatus({ interviewId: interviewHistory.id, status: IN_PROGRESS });
       }
     };

--- a/src/features/interview/question-display-with-timer.tsx
+++ b/src/features/interview/question-display-with-timer.tsx
@@ -21,6 +21,12 @@ const QuestionDisplayWithTimer = ({ interviewHistory, interviewQnAList }: Props)
   const { isRecording, isAIVoicePlaying, formattedTime, aiQuestion, startRecordingWithTimer, stopRecordingWithTimer } =
     useAudioWithTimer({ duration: MINUTES_IN_MS, interviewHistory });
 
+  let lastQuestion = interviewQnAList.at(CHECK_LAST_INDEX)?.question;
+
+  if (interviewQnAList.at(CHECK_LAST_INDEX)?.answer) {
+    lastQuestion = null;
+  }
+
   if (!interviewQnAList && interviewHistory.status === IN_PROGRESS) {
     return (
       <section className='mt-20 flex items-center justify-center'>
@@ -28,17 +34,10 @@ const QuestionDisplayWithTimer = ({ interviewHistory, interviewQnAList }: Props)
       </section>
     );
   }
+
   return (
     <section className='flex gap-5'>
-      <QuestionDisplay
-        interviewHistory={interviewHistory}
-        aiQuestion={
-          aiQuestion || interviewQnAList.at(CHECK_LAST_INDEX)?.answer
-            ? '대기중..'
-            : interviewQnAList.at(CHECK_LAST_INDEX)?.question ||
-              '면접 준비가 완료되었다면, 말하기 버튼을 눌러 자기 소개를 해주세요.'
-        }
-      />
+      <QuestionDisplay interviewHistory={interviewHistory} aiQuestion={aiQuestion || lastQuestion || '대기 중...'} />
       <Timer
         interviewHistory={interviewHistory}
         isRecording={isRecording}

--- a/src/features/interview/question-display-with-timer.tsx
+++ b/src/features/interview/question-display-with-timer.tsx
@@ -10,6 +10,7 @@ import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
 
 const MINUTES_IN_MS = 1 * 60 * 1000;
 const { IN_PROGRESS } = INTERVIEW_HISTORY_STATUS;
+const CHECK_LAST_INDEX = -1;
 
 type Props = {
   interviewHistory: InterviewHistoryType;
@@ -32,9 +33,10 @@ const QuestionDisplayWithTimer = ({ interviewHistory, interviewQnAList }: Props)
       <QuestionDisplay
         interviewHistory={interviewHistory}
         aiQuestion={
-          aiQuestion ||
-          interviewQnAList.at(-1)?.question ||
-          '면접 준비가 완료되었다면, 말하기 버튼을 눌러 자기 소개를 해주세요.'
+          aiQuestion || interviewQnAList.at(CHECK_LAST_INDEX)?.answer
+            ? '대기중..'
+            : interviewQnAList.at(CHECK_LAST_INDEX)?.question ||
+              '면접 준비가 완료되었다면, 말하기 버튼을 눌러 자기 소개를 해주세요.'
         }
       />
       <Timer

--- a/src/features/interview/question-display.tsx
+++ b/src/features/interview/question-display.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 const QuestionDisplay = ({ interviewHistory, aiQuestion }: Props) => {
-  const { interviewType, id } = interviewHistory;
+  const { interviewType } = interviewHistory;
 
   const interviewImage = interviewType === CALM ? 2 : 3; // TODO: 면접관 이미지 확정되면 수정
   const isInterviewTypeCalm = interviewType === CALM;


### PR DESCRIPTION
## 💡 관련이슈

- #202 

## 🍀 작업 요약

- 면접 종료 이후에도 진행이 되던 문제 수정

## 💬 리뷰 요구 사항

- 면접 종료 후 동일한 URL로 접근 가능한지 여부 확인 부탁드립니다!

### ✔️ 이슈 닫기

Closes #202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 인터뷰 진행 상태가 마지막 질문에 도달하지 않은 경우에만 '진행 중' 상태로 저장되도록 개선되었습니다.

- **리팩터**
  - 불필요한 상태 변수와 상수 정리가 이루어졌으며, 질문 인덱스 추적 방식이 개선되었습니다.
  - 질문 표시 로직이 변경되어, 답변이 있거나 AI 질문이 있을 때 '대기 중...' 메시지가 우선 표시됩니다.
  - 인터뷰 기록 관련 프로퍼티 구조가 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->