### PR TITLE
Refactor/#206 confirm

### DIFF
--- a/src/constants/notiflix-constants.ts
+++ b/src/constants/notiflix-constants.ts
@@ -1,5 +1,13 @@
 export const NOTIFLIX_CONFIRM_DEFAULT = {
-  OK: '확인',
-  CANCEL: '취소',
+  OK_BUTTON_TEXT: '확인',
+  CANCEL_BUTTON_TEXT: '취소',
   CONFIRM: 'Confirm',
+};
+
+// Notiflix 관련 상수는 밑쪽에 추가해주세요.
+export const NOTIFLIX_CONFIRM_SAMPLE = {
+  TITLE: 'sample title',
+  MESSAGE: 'sample message',
+  OK_BUTTON_TEXT: 'sample ok',
+  CANCEL_BUTTON_TEXT: 'cancel CANCEL',
 };

--- a/src/constants/notiflix-constants.ts
+++ b/src/constants/notiflix-constants.ts
@@ -1,4 +1,4 @@
-export const NOTIFLIX_CONFIRM = {
+export const NOTIFLIX_CONFIRM_DEFAULT = {
   OK: '확인',
   CANCEL: '취소',
   CONFIRM: 'Confirm',

--- a/src/styles/notiflix-styles.ts
+++ b/src/styles/notiflix-styles.ts
@@ -26,7 +26,7 @@ export const initNotiflix = () => {
     messageFontSize: '16px',
     messageMaxLength: 110,
     buttonsFontSize: '16px',
-    buttonsMaxLength: 34,
+    buttonsMaxLength: 10,
     okButtonColor: '#ffffff',
     okButtonBackground: '#E55A27',
     cancelButtonColor: '#ffffff',

--- a/src/utils/show-notiflix-confirm.ts
+++ b/src/utils/show-notiflix-confirm.ts
@@ -1,28 +1,41 @@
-import { NOTIFLIX_CONFIRM } from '@/constants/notiflix-constants';
 import { Confirm } from 'notiflix';
+import { NOTIFLIX_CONFIRM_DEFAULT } from '@/constants/notiflix-constants';
 
-const { OK, CANCEL, CONFIRM } = NOTIFLIX_CONFIRM;
+const { OK_BUTTON_TEXT, CANCEL_BUTTON_TEXT, CONFIRM } = NOTIFLIX_CONFIRM_DEFAULT;
 
 type Props = {
+  title?: string;
   message: string;
+  okButtonText?: string;
+  cancelButtonText?: string;
   okFunction: () => void;
   cancelFunction?: () => void;
 };
 
 /**
  * Confirm창 보여주는 함수
+ * @param {String} title confirm창에서 보여줄 메시지의 제목
  * @param {String} message confirm창에서 보여줄 메시지
+ * @param {String} okButtonText 확인 버튼명
+ * @param {String} cancelButtonText 취소 버튼명
  * @param {Function} okFunction 확인 버튼을 눌렀을 때 실행하는 함수
  * @param {Function} cancelFunction 취소 버튼을 눌렀을 때 실행하는 함수
  */
-export const showNotiflixConfirm = ({ message, okFunction, cancelFunction }: Props) => {
+export const showNotiflixConfirm = ({
+  title = CONFIRM,
+  message,
+  okButtonText = OK_BUTTON_TEXT,
+  cancelButtonText = CANCEL_BUTTON_TEXT,
+  okFunction,
+  cancelFunction,
+}: Props) => {
   document.body.classList.add('confirm-open');
 
   Confirm.show(
-    CONFIRM,
-    `${message}`,
-    OK,
-    CANCEL,
+    title,
+    message,
+    okButtonText,
+    cancelButtonText,
     () => {
       document.body.classList.remove('confirm-open');
       okFunction();

--- a/src/utils/show-notiflix-confirm.ts
+++ b/src/utils/show-notiflix-confirm.ts
@@ -14,7 +14,7 @@ type Props = {
 
 /**
  * Confirm창 보여주는 함수
- * @param {String} title confirm창에서 보여줄 메시지의 제목
+ * @param {String} title confirm창에서 보여줄 제목
  * @param {String} message confirm창에서 보여줄 메시지
  * @param {String} okButtonText 확인 버튼명
  * @param {String} cancelButtonText 취소 버튼명


### PR DESCRIPTION
## 💡 관련이슈
- #206 

## 🍀 작업 요약
- confirm 함수에서 추가적인 Props를 받을 수 있도록 수정하였습니다.
추가된 `props` = title, okButtonText, cancelButtonText
해당 내용은 따로 props로 전달하지 않아도 기본값이 보여지도록 설정하였습니다.

## 💬 리뷰 요구 사항

## 💛 미리보기
❌

### ✔️ 이슈 닫기

Closes #206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 확인(Confirm) 다이얼로그에 제목, 확인 버튼 텍스트, 취소 버튼 텍스트를 옵션으로 지정할 수 있습니다.

- **버그 수정**
  - 확인(Confirm) 다이얼로그의 버튼 텍스트 최대 길이가 10자로 제한되었습니다.

- **문서화**
  - 함수 설명에 새로운 옵션 파라미터가 추가되었습니다.

- **리팩터**
  - 확인 다이얼로그 관련 상수 및 키 이름이 더 명확하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->