### PR TITLE
style:#208 카드 css 수정

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ export default Card;
 //TODO: bg-emerald-900/0 -> color 수정, outline-gray-200 -> color 수정
 const cardClassName = clsx(
   'relative flex-shrink-0 items-start justify-between rounded-lg bg-emerald-900/0 outline outline-1 outline-offset-[-1px] outline-gray-200',
-  'min-w-[380px] p-6'
+  'min-w-[380px] min-h-[180px] p-6'
 );
 
 const contentClassName = clsx('flex h-full flex-col justify-between');

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ export default Card;
 //TODO: bg-emerald-900/0 -> color 수정, outline-gray-200 -> color 수정
 const cardClassName = clsx(
   'relative flex-shrink-0 items-start justify-between rounded-lg bg-emerald-900/0 outline outline-1 outline-offset-[-1px] outline-gray-200',
-  'w-80 h-44 p-6'
+  'min-w-[380px] p-6'
 );
 
 const contentClassName = clsx('flex h-full flex-col justify-between');

--- a/src/features/job/job-posting-card.tsx
+++ b/src/features/job/job-posting-card.tsx
@@ -22,7 +22,7 @@ const JobPostingCard = ({ jobPosting, userId }: Props) => {
   const remainDay = formatRemainDay(expirationTimestamp);
 
   return (
-    <Card className='h-full min-w-96 p-8'>
+    <Card className='h-full p-8'>
       <article className='flex flex-col justify-between'>
         <section className='h-24'>
           <div className='flex flex-row justify-between'>

--- a/src/features/job/job-postings-box.tsx
+++ b/src/features/job/job-postings-box.tsx
@@ -81,7 +81,7 @@ const JobPostingsBox = ({ userId }: Props) => {
 
     return (
       <>
-        <div className='flex flex-wrap justify-between gap-2'>
+        <div className='grid grid-cols-3 gap-2'>
           {data.jobPostingList.map((jobPosting) => (
             <JobPostingCard key={jobPosting.id} userId={userId} jobPosting={jobPosting} />
           ))}


### PR DESCRIPTION
## 💡 관련이슈

- #208 

## 🍀 작업 요약

- 채용공고 카드 사이가 너무 넓어서 배포 전 급하게 수정했습니다.
- 카드가 조금 커지긴 했는데, 추후 반응형 적용하면 해결될 문제로 보입니다. ( 아직 break points 미정이라 적용 X )

## 💬 리뷰 요구 사항

-채용 공고 페이지가 잘 나오는지 확인 부탁드립니다.

## 💛 미리보기

> 사진이나 gif 등 미리 볼 수 있는 파일을 제공해주세요.

### ✔️ 이슈 닫기

Closes #208 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 카드 컴포넌트의 크기 제한을 수정하여 더 유연한 최소 너비와 높이를 적용했습니다.
  - 채용공고 카드에서 최소 너비 제한을 제거했습니다.
  - 채용공고 목록의 레이아웃을 플렉스에서 3열 그리드로 변경하여 시각적 배열을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->