### PR TITLE
Refactor/#205 resume

### DIFF
--- a/src/app/(with-nav)/(with-header)/resume/page.tsx
+++ b/src/app/(with-nav)/(with-header)/resume/page.tsx
@@ -26,7 +26,7 @@ const ResumePage = async () => {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <section className='mx-auto flex w-full max-w-[853px] flex-col gap-4'>
         <Typography as='h2' size='2xl' weight='bold'>
-          <span className='text-primary-orange-600'>자소서</span>를 작성 해 볼까요?
+          <span className='text-primary-orange-600'>자소서</span>를 작성해 볼까요?
         </Typography>
         <ResumeForm />
       </section>

--- a/src/app/api/resume/count/route.ts
+++ b/src/app/api/resume/count/route.ts
@@ -1,5 +1,6 @@
+import { CHARACTER_HISTORY_KOR } from '@/constants/character-constants';
 import { ENV } from '@/constants/env-constants';
-import { AUTH_MESSAGE, RESUME_MESSAGE } from '@/constants/message-constants';
+import { AUTH_MESSAGE, CHARACTER_MESSAGE, RESUME_MESSAGE } from '@/constants/message-constants';
 import { prisma } from '@/lib/prisma';
 import { authOptions } from '@/utils/auth-option';
 import { getServerSession } from 'next-auth';
@@ -7,11 +8,13 @@ import { getToken } from 'next-auth/jwt';
 import { NextRequest, NextResponse } from 'next/server';
 
 const { NEXTAUTH_SECRET } = ENV;
+const { RESUME_SUBMISSION } = CHARACTER_HISTORY_KOR;
 const {
   ERROR: { EXPIRED_TOKEN },
   RESULT: { AUTH_REQUIRED },
 } = AUTH_MESSAGE;
 const { GET_COUNT_ERROR } = RESUME_MESSAGE;
+const { INFO: GET_DATA_NULL } = CHARACTER_MESSAGE;
 const MAX_COUNT_TO_GET_EXP_DURING_A_DAY = 3;
 export const GET = async (request: NextRequest) => {
   try {
@@ -25,15 +28,30 @@ export const GET = async (request: NextRequest) => {
     const startOfDay = new Date(today.setHours(0, 0, 0, 0));
     const endOfDay = new Date(today.setHours(23, 59, 59, 999));
 
-    const response = await prisma.resume.count({
+    const characterId = await prisma.character.findFirst({
       where: {
         userId: session.user.id,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (!characterId) {
+      return NextResponse.json({ response: { isAbleToGetEXP: false } }, { status: 200 });
+    }
+
+    const response = await prisma.characterHistory.count({
+      where: {
+        characterId: characterId.id,
+        history: RESUME_SUBMISSION,
         createdAt: {
           gte: startOfDay,
           lte: endOfDay,
         },
       },
     });
+
     if (response <= MAX_COUNT_TO_GET_EXP_DURING_A_DAY) {
       return NextResponse.json({ response: { isAbleToGetEXP: true } }, { status: 200 });
     }

--- a/src/app/api/resume/count/route.ts
+++ b/src/app/api/resume/count/route.ts
@@ -38,6 +38,7 @@ export const GET = async (request: NextRequest) => {
     });
 
     if (!characterId) {
+      // TODO: 캐릭터가 없을 시 어떤 상태값을 반환할 지 고민이 필요함
       return NextResponse.json({ response: { isAbleToGetEXP: false } }, { status: 200 });
     }
 

--- a/src/constants/message-constants.ts
+++ b/src/constants/message-constants.ts
@@ -1,4 +1,5 @@
-import { USER_META_DATA_KEY } from './user-meta-data-constants';
+import { CHARACTER_HISTORY, CHARACTER_HISTORY_KEY } from '@/constants/character-constants';
+import { USER_META_DATA_KEY } from '@/constants/user-meta-data-constants';
 
 export const AUTH_MESSAGE = {
   VALIDATION: {
@@ -43,12 +44,15 @@ export const AI_MESSAGE = {
   },
 };
 
+const { RESUME_SUBMISSION } = CHARACTER_HISTORY_KEY;
+const EXP = CHARACTER_HISTORY[RESUME_SUBMISSION].amount;
+
 export const RESUME_MESSAGE = {
   SUBMIT: {
     REQUEST_FAILURE: '유효하지 않은 자소서 양식입니다.',
     SUBMIT_SERVER_ERROR: '자소서 생성에 실패했습니다.',
-    SUCCESS_WITH_EXP: '경험치 획득 완료! 자기소개서 작성이 완료되었습니다.',
-    SUCCESS: '자기소개서 작성이 완료되었습니다.'
+    SUCCESS_WITH_EXP: `자기소개서 작성이 완료되었습니다. ${EXP} 경험치 획득 완료!`,
+    SUCCESS: '자기소개서 작성이 완료되었습니다.',
   },
   DRAFT: {
     NOT_FOUND: '해당 자소서를 찾을 수 없습니다.',

--- a/src/constants/message-constants.ts
+++ b/src/constants/message-constants.ts
@@ -70,7 +70,6 @@ export const RESUME_MESSAGE = {
   GET_COUNT_ERROR: '경험치 지급을 위해 오늘 작성한 자소서를 확인하는데 실패했습니다.',
   LIMIT: {
     MAX_RESUME_FIELD: '자소서 항목은 최대 5개까지 추가할 수 있습니다.',
-    MIN_RESUME_FIELD: '자소서 항목은 최소 1개 이상 작성해야됩니다.',
   },
   CONFIRM: {
     DELETE: '자소서를 정말로 삭제하시겠습니까?',

--- a/src/constants/message-constants.ts
+++ b/src/constants/message-constants.ts
@@ -47,6 +47,8 @@ export const RESUME_MESSAGE = {
   SUBMIT: {
     REQUEST_FAILURE: '유효하지 않은 자소서 양식입니다.',
     SUBMIT_SERVER_ERROR: '자소서 생성에 실패했습니다.',
+    SUCCESS_WITH_EXP: '경험치 획득 완료! 자기소개서 작성이 완료되었습니다.',
+    SUCCESS: '자기소개서 작성이 완료되었습니다.'
   },
   DRAFT: {
     NOT_FOUND: '해당 자소서를 찾을 수 없습니다.',

--- a/src/constants/message-constants.ts
+++ b/src/constants/message-constants.ts
@@ -68,9 +68,6 @@ export const RESUME_MESSAGE = {
   DELETE_SERVER_ERROR: '자소서를 삭제하는데 실패했습니다.',
   DELETE_FORBIDDEN: '해당 자소서를 삭제할 권한이 없습니다.',
   GET_COUNT_ERROR: '경험치 지급을 위해 오늘 작성한 자소서를 확인하는데 실패했습니다.',
-  LIMIT: {
-    MAX_RESUME_FIELD: '자소서 항목은 최대 5개까지 추가할 수 있습니다.',
-  },
   CONFIRM: {
     DELETE: '자소서를 정말로 삭제하시겠습니까?',
   },

--- a/src/features/resume/draft-resumes-modal.tsx
+++ b/src/features/resume/draft-resumes-modal.tsx
@@ -9,7 +9,7 @@ import { MODAL_ID } from '@/constants/modal-id-constants';
 import { showNotiflixConfirm } from '@/utils/show-notiflix-confirm';
 import { useDeleteResumeMutation } from '@/features/resume/hooks/use-delete-resume-mutation';
 import DraftResumeItem from '@/features/resume/draft-resume-item';
-import type { Resume } from '@prisma/client';
+import type { ResumeType } from '@/types/DTO/resume-dto';
 
 const { CONFIRM } = RESUME_MESSAGE;
 const { DRAFT_RESUME } = MODAL_ID;
@@ -17,9 +17,9 @@ const { RESUME_DRAFT } = QUERY_KEY;
 const EMPTY_DRAFT_COUNT = 0;
 
 type Props = {
-  draftResumeList: Resume[] | undefined;
+  draftResumeList: ResumeType[] | undefined;
   isError: boolean;
-  onLoadDraft: (resume: Resume) => void;
+  onLoadDraft: (resume: ResumeType) => void;
   activeResumeId: number | null;
   setResumeId: Dispatch<SetStateAction<number | null>>;
 };
@@ -39,7 +39,7 @@ const DraftResumesModal = ({ draftResumeList, isError, onLoadDraft, activeResume
     });
   };
 
-  const handleDraftResumeClick = (resume: Resume) => {
+  const handleDraftResumeClick = (resume: ResumeType) => {
     onLoadDraft(resume);
   };
 

--- a/src/features/resume/hooks/use-add-resume-mutation.ts
+++ b/src/features/resume/hooks/use-add-resume-mutation.ts
@@ -4,7 +4,7 @@ import { QUERY_KEY } from '@/constants/query-key';
 import type { ResumeData } from '@/types/resume';
 import type { Resume } from '@prisma/client';
 
-const { RESUMES } = QUERY_KEY;
+const { RESUMES, TABS_COUNT } = QUERY_KEY;
 
 type Props = {
   resumeId: number | null;
@@ -33,6 +33,9 @@ export const useAddResumeMutation = () => {
     onError: (error) => {
       throw error;
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: [RESUMES] }),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [RESUMES] });
+      queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
+    },
   });
 };

--- a/src/features/resume/hooks/use-add-resume-mutation.ts
+++ b/src/features/resume/hooks/use-add-resume-mutation.ts
@@ -33,7 +33,7 @@ export const useAddResumeMutation = () => {
     onError: (error) => {
       throw error;
     },
-    onSettled: () => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [RESUMES] });
       queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });
     },

--- a/src/features/resume/hooks/use-resume-form.ts
+++ b/src/features/resume/hooks/use-resume-form.ts
@@ -21,7 +21,6 @@ const { MY_PAGE } = PATH;
 const { DEFAULT } = DELAY_TIME;
 const { SAVING, SAVED } = AUTO_SAVE_STATUS;
 const { RESUME_SUBMISSION } = CHARACTER_HISTORY_KEY;
-const { LIMIT } = RESUME_MESSAGE;
 
 export const useResumeForm = (resume?: ResumeType) => {
   const router = useRouter();
@@ -58,10 +57,6 @@ export const useResumeForm = (resume?: ResumeType) => {
   };
 
   const handleAddField = () => {
-    if (fieldList.length >= 5) {
-      Notify.warning(LIMIT.MAX_RESUME_FIELD);
-      return;
-    }
     setFieldList((prev) => [...prev, { id: crypto.randomUUID(), question: '', answer: '' }]);
     setAutoSaveStatus(SAVING);
   };

--- a/src/features/resume/hooks/use-resume-form.ts
+++ b/src/features/resume/hooks/use-resume-form.ts
@@ -67,10 +67,6 @@ export const useResumeForm = (resume?: ResumeType) => {
   };
 
   const handleDeleteField = (fieldId: string) => {
-    if (fieldList.length <= 1) {
-      Notify.warning(LIMIT.MIN_RESUME_FIELD);
-      return;
-    }
     setFieldList((prev) => prev.filter((field) => field.id !== fieldId));
     setAutoSaveStatus(SAVING);
   };
@@ -119,9 +115,12 @@ export const useResumeForm = (resume?: ResumeType) => {
     });
   }, [debouncedTitle, debouncedFieldList]);
 
+  const fieldListLen = fieldList.length;
+
   return {
     title,
     fieldList,
+    fieldListLen,
     autoSaveStatus,
     resumeId,
     setTitle,

--- a/src/features/resume/hooks/use-resume-form.ts
+++ b/src/features/resume/hooks/use-resume-form.ts
@@ -15,7 +15,7 @@ import { defaultQuestionList } from '@/features/resume/data/default-question-lis
 import { useAddResumeMutation } from '@/features/resume/hooks/use-add-resume-mutation';
 import { CHARACTER_HISTORY_KEY } from '@/constants/character-constants';
 import type { Field } from '@/types/resume';
-import type { Resume } from '@prisma/client';
+import type { ResumeType } from '@/types/DTO/resume-dto';
 
 const { MY_PAGE } = PATH;
 const { DEFAULT } = DELAY_TIME;
@@ -23,7 +23,7 @@ const { SAVING, SAVED } = AUTO_SAVE_STATUS;
 const { RESUME_SUBMISSION } = CHARACTER_HISTORY_KEY;
 const { LIMIT } = RESUME_MESSAGE;
 
-export const useResumeForm = (resume?: Resume) => {
+export const useResumeForm = (resume?: ResumeType) => {
   const router = useRouter();
   const characterId = useCharacterStore((state) => state.characterId);
   const { handleExperienceUp } = useExperienceUp();

--- a/src/features/resume/hooks/use-resume-form.ts
+++ b/src/features/resume/hooks/use-resume-form.ts
@@ -50,7 +50,9 @@ export const useResumeForm = (resume?: ResumeType) => {
 
   const handleFieldChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     const { id, name, value } = event.target;
-    setFieldList((prev) => prev.map((field) => (field.id === id ? { ...field, [name]: value } : field)));
+    const [, realId] = id.split('-');
+
+    setFieldList((prev) => prev.map((field) => (field.id === realId ? { ...field, [name]: value } : field)));
     setIsDirty(true);
     setAutoSaveStatus(SAVING);
   };
@@ -86,11 +88,7 @@ export const useResumeForm = (resume?: ResumeType) => {
         if (isAbleToGetEXP) handleExperienceUp(RESUME_SUBMISSION);
       }
 
-      Notify.success(
-        isReqExp && isAbleToGetEXP
-          ? SUCCESS_WITH_EXP
-          : SUCCESS
-      );
+      Notify.success(isReqExp && isAbleToGetEXP ? SUCCESS_WITH_EXP : SUCCESS);
 
       // TODO: 이동하기 전 zustand를 통해 마이페이지의 탭 자기소개서 선택되도록
       router.push(MY_PAGE);

--- a/src/features/resume/hooks/use-resume-form.ts
+++ b/src/features/resume/hooks/use-resume-form.ts
@@ -37,6 +37,10 @@ export const useResumeForm = (resume?: Resume) => {
   const [resumeId, setResumeId] = useState<number | null>(resume?.id || null);
   const [autoSaveStatus, setAutoSaveStatus] = useState<string>(SAVING);
 
+  const {
+    SUBMIT: { SUCCESS_WITH_EXP, SUCCESS },
+  } = RESUME_MESSAGE;
+
   /** function */
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLInputElement>) => {
     setTitle(event.target.value);
@@ -82,17 +86,17 @@ export const useResumeForm = (resume?: Resume) => {
         if (isAbleToGetEXP) handleExperienceUp(RESUME_SUBMISSION);
       }
 
-      // 수정해야되는 alert창
-      alert(
+      Notify.success(
         isReqExp && isAbleToGetEXP
-          ? `경험치 획득 완료!\n자기소개서 작성이 완료되었습니다.`
-          : '자기소개서 작성이 완료되었습니다.'
+          ? SUCCESS_WITH_EXP
+          : SUCCESS
       );
 
+      // TODO: 이동하기 전 zustand를 통해 마이페이지의 탭 자기소개서 선택되도록
       router.push(MY_PAGE);
     } catch (error) {
       if (error instanceof Error) {
-        alert(error.message);
+        Notify.warning(error.message);
       }
     }
   };

--- a/src/features/resume/hooks/use-resume-form.ts
+++ b/src/features/resume/hooks/use-resume-form.ts
@@ -49,9 +49,9 @@ export const useResumeForm = (resume?: ResumeType) => {
 
   const handleFieldChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     const { id, name, value } = event.target;
-    const [, realId] = id.split('-');
+    const [, ...realId] = id.split('-');
 
-    setFieldList((prev) => prev.map((field) => (field.id === realId ? { ...field, [name]: value } : field)));
+    setFieldList((prev) => prev.map((field) => (field.id === realId.join('-') ? { ...field, [name]: value } : field)));
     setIsDirty(true);
     setAutoSaveStatus(SAVING);
   };

--- a/src/features/resume/question-answer-field.tsx
+++ b/src/features/resume/question-answer-field.tsx
@@ -15,7 +15,7 @@ const QuestionAnswerField = ({ field, idx, onChange, onDelete }: Props) => {
   const { id, question, answer } = field;
 
   return (
-    <div className='flex min-h-[444px] w-full flex-col gap-4 rounded-lg border border-cool-gray-200 p-8'>
+    <div className='flex min-h-[444px] h-[444px] w-full flex-col gap-4 rounded-lg border border-cool-gray-200 p-8'>
       <div className='flex flex-col gap-2'>
         <div className='flex w-full justify-between'>
           <Typography weight='normal' color='primary-600'>

--- a/src/features/resume/question-answer-field.tsx
+++ b/src/features/resume/question-answer-field.tsx
@@ -21,7 +21,7 @@ const QuestionAnswerField = ({ field, idx, onChange, onDelete }: Props) => {
           <Typography weight='normal' color='primary-600'>
             질문 {idx + 1}
           </Typography>
-          <button type='button' onClick={() => onDelete(id)}>
+          <button type='button' onClick={() => onDelete(id)} aria-label='질문 삭제'>
             <Trash />
           </button>
         </div>

--- a/src/features/resume/question-answer-field.tsx
+++ b/src/features/resume/question-answer-field.tsx
@@ -15,7 +15,7 @@ const QuestionAnswerField = ({ field, idx, onChange, onDelete }: Props) => {
   const { id, question, answer } = field;
 
   return (
-    <div className='flex h-[444px] w-full flex-col gap-4 rounded-lg border border-cool-gray-200 p-8'>
+    <div className='flex min-h-[444px] w-full flex-col gap-4 rounded-lg border border-cool-gray-200 p-8'>
       <div className='flex flex-col gap-2'>
         <div className='flex w-full justify-between'>
           <Typography weight='normal' color='primary-600'>

--- a/src/features/resume/question-answer-field.tsx
+++ b/src/features/resume/question-answer-field.tsx
@@ -6,12 +6,13 @@ const MAX_ANSWER_LENGTH = 1000;
 
 type Props = {
   field: Field;
+  fieldListLen: number;
   idx: number;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
   onDelete: (fieldId: string) => void;
 };
 
-const QuestionAnswerField = ({ field, idx, onChange, onDelete }: Props) => {
+const QuestionAnswerField = ({ field, fieldListLen, idx, onChange, onDelete }: Props) => {
   const { id, question, answer } = field;
 
   return (
@@ -21,9 +22,11 @@ const QuestionAnswerField = ({ field, idx, onChange, onDelete }: Props) => {
           <Typography weight='normal' color='primary-600'>
             질문 {idx + 1}
           </Typography>
-          <button type='button' onClick={() => onDelete(id)} aria-label='질문 삭제'>
-            <Trash />
-          </button>
+          {fieldListLen > 1 && (
+            <button type='button' onClick={() => onDelete(id)} aria-label='질문 삭제'>
+              <Trash />
+            </button>
+          )}
         </div>
         <input
           id={`question-${id}`}

--- a/src/features/resume/question-answer-field.tsx
+++ b/src/features/resume/question-answer-field.tsx
@@ -2,8 +2,6 @@ import Trash from '@/components/icons/trash';
 import Typography from '@/components/ui/typography';
 import type { Field } from '@/types/resume';
 
-const MAX_ANSWER_LENGTH = 1000;
-
 type Props = {
   field: Field;
   fieldListLen: number;
@@ -11,6 +9,9 @@ type Props = {
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
   onDelete: (fieldId: string) => void;
 };
+
+const MAX_ANSWER_LENGTH = 1000;
+const MIN_RESUME_FIELD_COUNT = 1;
 
 const QuestionAnswerField = ({ field, fieldListLen, idx, onChange, onDelete }: Props) => {
   const { id, question, answer } = field;
@@ -22,7 +23,7 @@ const QuestionAnswerField = ({ field, fieldListLen, idx, onChange, onDelete }: P
           <Typography weight='normal' color='primary-600'>
             질문 {idx + 1}
           </Typography>
-          {fieldListLen > 1 && (
+          {fieldListLen > MIN_RESUME_FIELD_COUNT && (
             <button type='button' onClick={() => onDelete(id)} aria-label='질문 삭제'>
               <Trash />
             </button>

--- a/src/features/resume/question-answer-field.tsx
+++ b/src/features/resume/question-answer-field.tsx
@@ -15,7 +15,7 @@ const QuestionAnswerField = ({ field, idx, onChange, onDelete }: Props) => {
   const { id, question, answer } = field;
 
   return (
-    <div className='flex min-h-[444px] h-[444px] w-full flex-col gap-4 rounded-lg border border-cool-gray-200 p-8'>
+    <div className='flex h-[444px] min-h-[444px] w-full flex-col gap-4 rounded-lg border border-cool-gray-200 p-8'>
       <div className='flex flex-col gap-2'>
         <div className='flex w-full justify-between'>
           <Typography weight='normal' color='primary-600'>
@@ -26,7 +26,7 @@ const QuestionAnswerField = ({ field, idx, onChange, onDelete }: Props) => {
           </button>
         </div>
         <input
-          id={String(id)}
+          id={`question-${id}`}
           name='question'
           value={question}
           onChange={onChange}
@@ -37,7 +37,7 @@ const QuestionAnswerField = ({ field, idx, onChange, onDelete }: Props) => {
       </div>
       <hr className='border-cool-gray-500' />
       <textarea
-        id={String(id)}
+        id={`answer-${id}`}
         name='answer'
         value={answer}
         onChange={onChange}

--- a/src/features/resume/resume-form-action-button.tsx
+++ b/src/features/resume/resume-form-action-button.tsx
@@ -1,5 +1,6 @@
 import Button from '@/components/ui/button';
 import Typography from '@/components/ui/typography';
+import { AUTO_SAVE_STATUS } from '@/constants/resume-constants';
 import type { ResumeType } from '@/types/DTO/resume-dto';
 
 type Props = {
@@ -8,6 +9,8 @@ type Props = {
   autoSaveStatus: string;
   onClick: () => void;
 };
+
+const { SAVED } = AUTO_SAVE_STATUS;
 
 const ResumeFormActionButton = ({ resume, draftResumeList, autoSaveStatus, onClick }: Props) => {
   return (
@@ -26,7 +29,7 @@ const ResumeFormActionButton = ({ resume, draftResumeList, autoSaveStatus, onCli
           </Button>
         </div>
       )}
-      <Typography color='gray-500'>{autoSaveStatus}</Typography>
+      <Typography color={autoSaveStatus === SAVED ? 'primary-600' : 'gray-500'}>{autoSaveStatus}</Typography>
     </div>
   );
 };

--- a/src/features/resume/resume-form-action-button.tsx
+++ b/src/features/resume/resume-form-action-button.tsx
@@ -1,10 +1,10 @@
 import Button from '@/components/ui/button';
 import Typography from '@/components/ui/typography';
-import { Resume } from '@prisma/client';
+import type { ResumeType } from '@/types/DTO/resume-dto';
 
 type Props = {
-  resume?: Resume;
-  draftResumeList?: Resume[];
+  resume?: ResumeType;
+  draftResumeList?: ResumeType[];
   autoSaveStatus: string;
   onClick: () => void;
 };

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -9,7 +9,7 @@ import QuestionAnswerField from '@/features/resume/question-answer-field';
 import DraftResumesModal from '@/features/resume/draft-resumes-modal';
 import ResumeFormActionButton from '@/features/resume/resume-form-action-button';
 import type { Field } from '@/types/resume';
-import type{ ResumeType } from '@/types/DTO/resume-dto';
+import type { ResumeType } from '@/types/DTO/resume-dto';
 
 const { DRAFT_RESUME } = MODAL_ID;
 

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -9,12 +9,12 @@ import QuestionAnswerField from '@/features/resume/question-answer-field';
 import DraftResumesModal from '@/features/resume/draft-resumes-modal';
 import ResumeFormActionButton from '@/features/resume/resume-form-action-button';
 import type { Field } from '@/types/resume';
-import type { Resume } from '@prisma/client';
+import type{ ResumeType } from '@/types/DTO/resume-dto';
 
 const { DRAFT_RESUME } = MODAL_ID;
 
 type Props = {
-  resume?: Resume;
+  resume?: ResumeType;
 };
 
 const ResumeForm = ({ resume }: Props) => {
@@ -45,7 +45,7 @@ const ResumeForm = ({ resume }: Props) => {
     refetch();
   };
 
-  const handleLoadDraft = (resume: Resume) => {
+  const handleLoadDraft = (resume: ResumeType) => {
     const { id, title, content } = resume;
 
     setTitle(title);

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -25,6 +25,7 @@ const ResumeForm = ({ resume }: Props) => {
   const {
     title,
     fieldList,
+    fieldListLen,
     autoSaveStatus,
     resumeId,
     setTitle,
@@ -81,11 +82,12 @@ const ResumeForm = ({ resume }: Props) => {
       </div>
 
       {/* 중간 스크롤 영역 */}
-      <div className='flex flex-col flex-1 overflow-y-auto max-h-[467px] scrollbar-hide gap-2'>
+      <div className='flex max-h-[467px] flex-1 flex-col gap-2 overflow-y-auto scrollbar-hide'>
         {fieldList.map((field, idx) => (
           <QuestionAnswerField
             key={field.id}
             field={field}
+            fieldListLen={fieldListLen}
             idx={idx}
             onChange={handleFieldChange}
             onDelete={handleDeleteField}

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -11,11 +11,12 @@ import ResumeFormActionButton from '@/features/resume/resume-form-action-button'
 import type { Field } from '@/types/resume';
 import type { ResumeType } from '@/types/DTO/resume-dto';
 
-const { DRAFT_RESUME } = MODAL_ID;
-
 type Props = {
   resume?: ResumeType;
 };
+
+const { DRAFT_RESUME } = MODAL_ID;
+const MAX_RESIME_FIELD_COUNT = 5;
 
 const ResumeForm = ({ resume }: Props) => {
   const toggleModal = useModalStore((state) => state.toggleModal);
@@ -72,7 +73,7 @@ const ResumeForm = ({ resume }: Props) => {
           required
           className='h-[64px] w-full rounded-lg border border-cool-gray-200 px-8 py-4 pr-52 text-xl font-bold placeholder-cool-gray-300 focus:outline-none'
         />
-        {fieldListLen < 5 && (
+        {fieldListLen < MAX_RESIME_FIELD_COUNT && (
           <button
             type='button'
             onClick={handleAddField}

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -72,13 +72,15 @@ const ResumeForm = ({ resume }: Props) => {
           required
           className='h-[64px] w-full rounded-lg border border-cool-gray-200 px-8 py-4 pr-52 text-xl font-bold placeholder-cool-gray-300 focus:outline-none'
         />
-        <button
-          type='button'
-          onClick={handleAddField}
-          className='absolute right-4 top-1/2 w-[174px] -translate-y-1/2 rounded-3xl border border-cool-gray-900 bg-transparent px-5 py-1 font-bold text-cool-gray-900'
-        >
-          질문 추가 +
-        </button>
+        {fieldListLen < 5 && (
+          <button
+            type='button'
+            onClick={handleAddField}
+            className='absolute right-4 top-1/2 w-[174px] -translate-y-1/2 rounded-3xl border border-cool-gray-900 bg-transparent px-5 py-1 font-bold text-cool-gray-900'
+          >
+            질문 추가 +
+          </button>
+        )}
       </div>
 
       {/* 중간 스크롤 영역 */}

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -60,8 +60,9 @@ const ResumeForm = ({ resume }: Props) => {
 
   /** UI */
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-4'>
-      <div className='relative w-full'>
+    <form onSubmit={handleSubmit} className='flex flex-1 flex-col gap-4'>
+      {/* 상단 고정 영역 */}
+      <div className='relative w-full shrink-0'>
         <input
           type='text'
           value={title}
@@ -79,8 +80,9 @@ const ResumeForm = ({ resume }: Props) => {
         </button>
       </div>
 
-      {fieldList.map((field, idx) => {
-        return (
+      {/* 중간 스크롤 영역 */}
+      <div className='flex flex-col flex-1 overflow-y-auto max-h-[467px] scrollbar-hide gap-2'>
+        {fieldList.map((field, idx) => (
           <QuestionAnswerField
             key={field.id}
             field={field}
@@ -88,18 +90,20 @@ const ResumeForm = ({ resume }: Props) => {
             onChange={handleFieldChange}
             onDelete={handleDeleteField}
           />
-        );
-      })}
+        ))}
+      </div>
 
-      {/** 버튼 */}
-      <ResumeFormActionButton
-        resume={resume}
-        draftResumeList={draftResumeList}
-        autoSaveStatus={autoSaveStatus}
-        onClick={handleDraftResumeListClick}
-      />
+      {/* 하단 고정 영역 */}
+      <div className='shrink-0'>
+        <ResumeFormActionButton
+          resume={resume}
+          draftResumeList={draftResumeList}
+          autoSaveStatus={autoSaveStatus}
+          onClick={handleDraftResumeListClick}
+        />
+      </div>
 
-      {/** 모달 */}
+      {/* 모달 */}
       {isModalOpen && (
         <DraftResumesModal
           draftResumeList={draftResumeList}

--- a/src/features/resume/resume-form.tsx
+++ b/src/features/resume/resume-form.tsx
@@ -67,7 +67,7 @@ const ResumeForm = ({ resume }: Props) => {
           type='text'
           value={title}
           onChange={handleTitleChange}
-          placeholder='자소서 제목을 작성해주세요.'
+          placeholder='자소서 제목을 작성해 주세요.'
           required
           className='h-[64px] w-full rounded-lg border border-cool-gray-200 px-8 py-4 pr-52 text-xl font-bold placeholder-cool-gray-300 focus:outline-none'
         />


### PR DESCRIPTION
## 💡 관련이슈

- #205 

## 🍀 작업 요약

- alert -> notify(자소서 작성 완료 시)로 수정하였습니다.
- invalidate를 queryKey: [RESUMES]만으로 하여 마이페이지에서 tab counts에 반영 안되는 문제를 `queryClient.invalidateQueries({ queryKey: [TABS_COUNT] });`를 추가하여 TABS_COUNT에 관하여도 무효화가 일어날 수 있도록 수정하였습니다.
- type DTO 폴더에서 import 해오도록 수정하였습니다.
- 삭제 버튼에 식별할 수 있는 라벨이 없어 추가하였습니다.
- 기존 resume에 대하여 해당 날짜에 3개 올렸는지 판단하는 로직을 characterHistory 기준으로 해당 날짜에 3번 history가 등록되었는지 판단하는 직으로 변경하였습니다. (기존 로직은 자소서를 마이페이지에서 삭제할 경우 무한으로 경험치를 획득할 수 있음)
- 자소서 내용 입력 필드만 scroll이 되도록 구현했습니다.

## 💬 리뷰 요구 사항

> 없습니다~

## 💛 미리보기

![Apr-23-2025 22-08-17](https://github.com/user-attachments/assets/b38b06ad-ef37-421e-8abe-2e9fb1ba95b3)

### ✔️ 이슈 닫기

Closes #205


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 자기소개서 작성 시 경험치(Exp) 획득 가능 여부가 보다 정확하게 반영됩니다.
  - 경험치 획득 및 자기소개서 작성 완료 시 알림 메시지가 개선되었습니다.

- **스타일**
  - 자기소개서 폼 레이아웃이 세로 3단 구조로 개선되어 가독성이 향상되었습니다.
  - 질문/답변 필드의 최소 높이가 조정되어 더 안정적인 입력 환경을 제공합니다.
  - 자동 저장 상태에 따라 버튼 색상이 동적으로 변경됩니다.

- **접근성**
  - 질문 삭제 버튼에 스크린리더를 위한 aria-label이 추가되어 접근성이 향상되었습니다.
  - 질문 및 답변 입력 필드의 id가 더 명확하게 변경되어 접근성이 개선되었습니다.

- **기타**
  - 임시 저장 및 초안 로딩 등 자기소개서 관련 기능의 타입이 일관되게 개선되었습니다.
  - 알림 방식이 alert에서 Notify로 변경되어 사용자 경험이 향상되었습니다.
  - 자기소개서 작성 페이지 내 문구의 오탈자가 수정되었습니다.
  - 자기소개서 질문 추가/삭제 제한이 제거되어 자유로운 필드 관리가 가능합니다.
  - 자기소개서 경험치 획득 로직이 캐릭터 히스토리 기반으로 변경되어 일일 제한이 정확히 적용됩니다.
  - 자기소개서 작성 성공 메시지에 동적 경험치 정보가 포함되었습니다.
  - 자기소개서 작성 폼 내 질문 추가 버튼이 최대 5개 필드까지 조건부로 표시됩니다.
  - 질문/답변 필드 삭제 버튼은 최소 1개 필드 이상일 때만 노출됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->