### PR TITLE
Style/#214 confirm

### DIFF
--- a/src/styles/notiflix-styles.ts
+++ b/src/styles/notiflix-styles.ts
@@ -5,7 +5,7 @@ import { Confirm, Notify } from 'notiflix';
 export const initNotiflix = () => {
   Confirm.init({
     className: 'notiflix-confirm',
-    width: '402px',
+    width: '386px',
     zindex: 4003,
     position: 'center', // 'right-top' - 'right-bottom' - 'left-top' - 'left-bottom' - 'center-top' - 'center-bottom' - 'center-center'
     distance: '10px',
@@ -21,10 +21,10 @@ export const initNotiflix = () => {
     plainText: false,
     titleColor: '#E55A27',
     titleFontSize: '24px',
-    titleMaxLength: 34,
+    titleMaxLength: 10,
     messageColor: '#111827',
     messageFontSize: '16px',
-    messageMaxLength: 110,
+    messageMaxLength: 30,
     buttonsFontSize: '16px',
     buttonsMaxLength: 10,
     okButtonColor: '#ffffff',

--- a/src/styles/notiflix-styles.ts
+++ b/src/styles/notiflix-styles.ts
@@ -6,7 +6,6 @@ export const initNotiflix = () => {
   Confirm.init({
     className: 'notiflix-confirm',
     width: '386px',
-    zindex: 4003,
     position: 'center', // 'right-top' - 'right-bottom' - 'left-top' - 'left-bottom' - 'center-top' - 'center-bottom' - 'center-center'
     distance: '10px',
     backgroundColor: '#ffffff',
@@ -41,7 +40,7 @@ export const initNotiflix = () => {
     borderRadius: '10px',
     rtl: false,
     timeout: 2000,
-    messageMaxLength: 110,
+    messageMaxLength: 100,
     backOverlay: false,
     backOverlayColor: 'rgba(0,0,0,0.5)',
     plainText: true,
@@ -51,9 +50,8 @@ export const initNotiflix = () => {
 
     ID: 'NotiflixNotify',
     className: 'notiflix-notify',
-    zindex: 4001,
-    fontFamily: 'Quicksand',
-    fontSize: '13px',
+    fontFamily: 'SUIT Variable',
+    fontSize: '12px',
     cssAnimation: true,
     cssAnimationDuration: 400,
     cssAnimationStyle: 'fade', // 'fade' - 'zoom' - 'from-right' - 'from-top' - 'from-bottom' - 'from-left'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,7 +47,7 @@ const config: Config = {
         'rounded-full': '50%',
       },
       zIndex: {
-        alert: '4001',
+        'notiflix-alert': '4001',
         modal: '100',
         header: '90',
         overlay: '10',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,7 +47,7 @@ const config: Config = {
         'rounded-full': '50%',
       },
       zIndex: {
-        alert: ' 4001',
+        alert: '4001',
         modal: '100',
         header: '90',
         overlay: '10',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,6 +47,7 @@ const config: Config = {
         'rounded-full': '50%',
       },
       zIndex: {
+        alert: ' 4001',
         modal: '100',
         header: '90',
         overlay: '10',


### PR DESCRIPTION
## 💡 관련이슈
- #214 

## 🍀 작업 요약
- confirm창의 default값을 수정하였습니다.

따로 padding 적용할 수 없어서 지금의 선택이 최선인 상황입니다...
메시지는 한 줄로 작성하기로 결정하였습니다! 메시지 길이도 제한해둔 상태입니다.


## 💬 리뷰 요구 사항


## 💛 미리보기
<img width="1279" alt="스크린샷 2025-04-24 오전 12 17 13" src="https://github.com/user-attachments/assets/890dd337-d509-4a5d-9295-391e509be796" />


### ✔️ 이슈 닫기
Closes #214 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Confirm 및 Notify 알림창의 폰트 패밀리가 "SUIT Variable"로 변경되고, 폰트 크기가 12px로 축소되었습니다.
  - Confirm 알림창의 너비가 소폭 축소되고 z-index 설정이 제거되었습니다.
  - 알림창의 제목 및 메시지 최대 길이가 대폭 줄어들었습니다.
  - Notify 알림창 메시지 최대 길이가 소폭 감소하고 z-index 설정이 제거되었습니다.
- **New Features**
  - Tailwind CSS 설정에 새로운 z-index 값 `notiflix-alert`가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->