### PR TITLE
Style/#223 notiflix notify color

### DIFF
--- a/src/styles/notiflix-styles.ts
+++ b/src/styles/notiflix-styles.ts
@@ -67,7 +67,7 @@ export const initNotiflix = () => {
       childClassName: 'notiflix-notify-success',
       notiflixIconColor: '#D1D5DB',
       fontAwesomeClassName: 'fas fa-check-circle',
-      fontAwesomeIconColor: 'D1D5DB',
+      fontAwesomeIconColor: '#D1D5DB',
       backOverlayColor: 'rgba(55, 65, 81, 0.6)',
     },
 
@@ -97,7 +97,7 @@ export const initNotiflix = () => {
       childClassName: 'notiflix-notify-info',
       notiflixIconColor: '#D1D5DB',
       fontAwesomeClassName: 'fas fa-info-circle',
-      fontAwesomeIconColor: 'D1D5DB',
+      fontAwesomeIconColor: '#D1D5DB',
       backOverlayColor: 'rgba(55, 65, 81, 0.6)',
     },
   });

--- a/src/styles/notiflix-styles.ts
+++ b/src/styles/notiflix-styles.ts
@@ -72,7 +72,7 @@ export const initNotiflix = () => {
     },
 
     failure: {
-      background: '#C2410C',
+      background: '#FF3D01',
       textColor: '#ffffff',
       childClassName: 'notiflix-notify-failure',
       notiflixIconColor: 'rgba(0,0,0,0.2)',
@@ -92,7 +92,7 @@ export const initNotiflix = () => {
     },
 
     info: {
-      background: '#26c0d3',
+      background: '#536EFE',
       textColor: '#ffffff',
       childClassName: 'notiflix-notify-info',
       notiflixIconColor: 'rgba(0,0,0,0.2)',

--- a/src/styles/notiflix-styles.ts
+++ b/src/styles/notiflix-styles.ts
@@ -62,22 +62,22 @@ export const initNotiflix = () => {
     fontAwesomeIconSize: '34px',
 
     success: {
-      background: '#32c682',
+      background: '#374151',
       textColor: '#ffffff',
       childClassName: 'notiflix-notify-success',
-      notiflixIconColor: 'rgba(0,0,0,0.2)',
+      notiflixIconColor: '#D1D5DB',
       fontAwesomeClassName: 'fas fa-check-circle',
-      fontAwesomeIconColor: 'rgba(0,0,0,0.2)',
-      backOverlayColor: 'rgba(50,198,130,0.2)',
+      fontAwesomeIconColor: 'D1D5DB',
+      backOverlayColor: 'rgba(55, 65, 81, 0.6)',
     },
 
     failure: {
-      background: '#FF3D01',
+      background: '#E55A27',
       textColor: '#ffffff',
       childClassName: 'notiflix-notify-failure',
-      notiflixIconColor: 'rgba(0,0,0,0.2)',
+      notiflixIconColor: '#ffffff',
       fontAwesomeClassName: 'fas fa-times-circle',
-      fontAwesomeIconColor: 'rgba(0,0,0,0.2)',
+      fontAwesomeIconColor: '#ffffff',
       backOverlayColor: 'rgba(194, 65, 12, 0.2)',
     },
 
@@ -85,20 +85,20 @@ export const initNotiflix = () => {
       background: '#FBBF24',
       textColor: '#ffffff',
       childClassName: 'notiflix-notify-warning',
-      notiflixIconColor: 'rgba(0,0,0,0.2)',
+      notiflixIconColor: '#ffffff',
       fontAwesomeClassName: 'fas fa-exclamation-circle',
-      fontAwesomeIconColor: 'rgba(0,0,0,0.2)',
+      fontAwesomeIconColor: '#ffffff',
       backOverlayColor: 'rgba(251, 191, 36, 0.2)',
     },
 
     info: {
-      background: '#536EFE',
+      background: '#374151',
       textColor: '#ffffff',
       childClassName: 'notiflix-notify-info',
-      notiflixIconColor: 'rgba(0,0,0,0.2)',
+      notiflixIconColor: '#D1D5DB',
       fontAwesomeClassName: 'fas fa-info-circle',
-      fontAwesomeIconColor: 'rgba(0,0,0,0.2)',
-      backOverlayColor: 'rgba(38,192,211,0.2)',
+      fontAwesomeIconColor: 'D1D5DB',
+      backOverlayColor: 'rgba(55, 65, 81, 0.6)',
     },
   });
 };


### PR DESCRIPTION
## 💡 관련이슈
- #223 

## 🍀 작업 요약
- notiflix에서 제공하는 notify 템플릿의 색깔을 수정하였습니다
success, info -> cool-gray-700으로 통일
failure -> primary-600 사용
warning -> secondary-amber 사용

## 💬 리뷰 요구 사항


## 💛 미리보기


### ✔️ 이슈 닫기

Closes #223 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
  - Notify(알림) 컴포넌트의 성공, 실패, 경고, 정보 상태에 대한 색상 및 아이콘 색상 스타일이 업데이트되었습니다.  
  - 성공 및 정보 알림의 배경색이 어두운 회색(#374151)으로 변경되고, 실패 알림의 배경색이 밝은 오렌지색(#E55A27)으로 변경되었습니다.
  - 아이콘 색상이 더 밝은 회색(#D1D5DB) 또는 흰색(#ffffff)으로 조정되었습니다.  
  - 성공 및 정보 알림의 오버레이 색상이 어두운 반투명 회색(rgba(55, 65, 81, 0.6))으로 변경되었으며, 실패와 경고 알림의 오버레이 색상은 유지되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->