### PR TITLE
Style#235 responsive my page

### DIFF
--- a/src/app/(with-nav)/(with-header)/layout.tsx
+++ b/src/app/(with-nav)/(with-header)/layout.tsx
@@ -4,7 +4,7 @@ const HeaderLayout = async ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <Header />
-      <main className='mx-auto h-full min-h-screen max-w-max px-12 pb-8 pt-28'>{children}</main>
+      <main className='mobile:px-6 mx-auto h-full min-h-screen max-w-max px-12 pb-8 pt-28'>{children}</main>
     </>
   );
 };

--- a/src/app/(with-nav)/(with-header)/my-page/page.tsx
+++ b/src/app/(with-nav)/(with-header)/my-page/page.tsx
@@ -9,9 +9,8 @@ const MyPage = async () => {
   if (!session) return null;
 
   return (
-    <article className='mobile:gap-2 mobile:h-[calc(100%-65px)] flex h-full w-full flex-col items-stretch justify-evenly gap-5 desktop:flex-row'>
+    <article className='flex h-full w-full flex-col items-stretch justify-evenly gap-5 mobile:h-[calc(100%-65px)] mobile:gap-2 desktop:flex-row'>
       <ViewingField session={session} />
-
       <TabsField userId={session?.user.id} />
     </article>
   );

--- a/src/app/(with-nav)/(with-header)/my-page/page.tsx
+++ b/src/app/(with-nav)/(with-header)/my-page/page.tsx
@@ -1,7 +1,7 @@
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/utils/auth-option';
 import TabsField from '@/features/my-page/tabs-field';
 import ViewingField from '@/features/my-page/viewing-field';
+import { authOptions } from '@/utils/auth-option';
+import { getServerSession } from 'next-auth';
 
 const MyPage = async () => {
   const session = await getServerSession(authOptions);
@@ -9,8 +9,9 @@ const MyPage = async () => {
   if (!session) return null;
 
   return (
-    <article className='flex h-full w-full flex-col items-stretch justify-evenly gap-5 desktop:flex-row'>
+    <article className='mobile:gap-2 mobile:h-[calc(100%-65px)] flex h-full w-full flex-col items-stretch justify-evenly gap-5 desktop:flex-row'>
       <ViewingField session={session} />
+
       <TabsField userId={session?.user.id} />
     </article>
   );

--- a/src/app/(with-nav)/(with-header)/my-page/page.tsx
+++ b/src/app/(with-nav)/(with-header)/my-page/page.tsx
@@ -9,7 +9,7 @@ const MyPage = async () => {
   if (!session) return null;
 
   return (
-    <article className='flex h-full w-full items-stretch justify-evenly gap-5'>
+    <article className='flex h-full w-full flex-col items-stretch justify-evenly gap-5 desktop:flex-row'>
       <ViewingField session={session} />
       <TabsField userId={session?.user.id} />
     </article>

--- a/src/features/bookmark-selected/bookmark-tab.tsx
+++ b/src/features/bookmark-selected/bookmark-tab.tsx
@@ -47,16 +47,14 @@ const BookmarkTab = ({ bookmark, index, length, userId }: Props) => {
           <Typography size='sm' color='gray-500' weight='bold'>
             {companyName}
           </Typography>
-          <Typography weight='bold' size='lg' lineClamp='1'>
-            {positionTitle}
-          </Typography>
+          <Typography className='line-clamp-1 text-lg font-bold mobile:text-base'>{positionTitle}</Typography>
         </div>
         <button type='button' onClick={handleDeleteBookmark} aria-label='북마크 버튼'>
           <Star width='18' height='18' color='#FDE047' stroke='#FDE047' />
         </button>
       </div>
       <div className='flex w-full flex-row items-center justify-between'>
-        <div className='flex flex-row gap-6'>
+        <div className='flex flex-row gap-6 mobile:flex-col mobile:gap-2'>
           <Typography size='xs' color='gray-500'>
             {experienceType[experienceCode]}
           </Typography>
@@ -64,11 +62,11 @@ const BookmarkTab = ({ bookmark, index, length, userId }: Props) => {
             {postedAtDate}~{expiredAtDate}
           </Typography>
         </div>
-        <div className='flex flex-row items-center justify-between gap-3'>
+        <div className='flex flex-row items-center justify-between gap-3 mobile:flex-col mobile:gap-1'>
           {remainDay ? (
             <Typography color='primary-600'>D-{remainDay}</Typography>
           ) : (
-            <Typography color='primary-600'>날짜정보 오류</Typography>
+            <Typography className='text-primary-orange-600 mobile:text-sm'>날짜정보 오류</Typography>
           )}
           {bookmark.jobPosting.url && (
             <LinkButton target='_blank' size='small' href={bookmark.jobPosting.url} square>

--- a/src/features/character/character-detail-modal.tsx
+++ b/src/features/character/character-detail-modal.tsx
@@ -46,7 +46,10 @@ const CharacterDetailModal = ({ session }: Props) => {
             selectedTab === 'info' ? 'border-b-2 border-primary-orange-600 font-bold' : 'text-cool-gray-500'
           }`}
         >
-          <Typography size='2xl' weight='bold' color={selectedTab === 'info' ? 'primary-600' : 'gray-500'}>
+          <Typography
+            color={selectedTab === 'info' ? 'primary-600' : 'gray-500'}
+            className='text-2xl font-bold mobile:text-lg'
+          >
             My Mate
           </Typography>
         </button>
@@ -59,7 +62,10 @@ const CharacterDetailModal = ({ session }: Props) => {
               : 'text-cool-gray-500'
           }`}
         >
-          <Typography size='2xl' weight='bold' color={selectedTab === 'history' ? 'primary-600' : 'gray-500'}>
+          <Typography
+            className='text-2xl font-bold mobile:text-lg'
+            color={selectedTab === 'history' ? 'primary-600' : 'gray-500'}
+          >
             History
           </Typography>
         </button>

--- a/src/features/character/my-page-character-card.tsx
+++ b/src/features/character/my-page-character-card.tsx
@@ -47,7 +47,7 @@ const MyPageCharacterCard = ({
           </ScreenOverlay>
         )}
         <div className={`flex h-full justify-between ${isDefault && 'opacity-60'}`}>
-          <div className='flex items-center justify-center'>
+          <div className='mobile:w-[25vh] flex items-center justify-center'>
             <Image
               src={`/assets/character/card/${type}-level${level}.png`}
               width={242}
@@ -61,7 +61,7 @@ const MyPageCharacterCard = ({
               ChickMate
             </Typography>
             <div className='flex flex-col gap-1'>
-              <Typography size='3xl' weight='bold'>
+              <Typography className='mobile:text-lg mobile:whitespace-nowrap mobile:max-w-[150px] mobile:truncate text-3xl font-bold'>
                 {session && session.user.name}님
               </Typography>
               <Typography size='xs' color='gray-500'>
@@ -69,7 +69,11 @@ const MyPageCharacterCard = ({
               </Typography>
             </div>
             <div className='flex justify-end'>
-              <img src='/assets/character/card/card_assets.svg' alt='card-assets' className='w-[175px]' />
+              <img
+                src='/assets/character/card/card_assets.svg'
+                alt='card-assets'
+                className='mobile:w-[120px] w-[175px]'
+              />
             </div>
           </div>
         </div>

--- a/src/features/my-page/my-info-content.tsx
+++ b/src/features/my-page/my-info-content.tsx
@@ -27,23 +27,28 @@ const fieldList: FieldList[] = [
 const MyInfoContent = ({ data }: Props) => {
   const toggleModal = useModalStore((state) => state.toggleModal);
   return (
-    <div>
-      <ul className='mb-4 border-b border-t p-4'>
+    <div className='w-full'>
+      <ul className='scrollbar-hidden mb-4 flex overflow-x-auto desktop:block desktop:border-b desktop:border-t desktop:p-4'>
         {fieldList.map(({ key, label }, index) => {
           const isLastChild = fieldList.length === index + 1;
+          if (!data[key]) return null;
           return (
-            <li key={`my_info_list_${key}`} className={clsx(isLastChild ? 'mb-0' : 'mb-4')}>
-              <dl className='flex items-center'>
-                <dt className='mr-10 w-[180px] font-bold'>{label}</dt>
-                <dd className='text-coolgray-500'>{data[key]}</dd>
+            <li key={`my_info_list_${key}`} className={clsx(isLastChild ? 'mr-0 desktop:mb-0' : 'mr-4 desktop:mb-4')}>
+              <dl className='flex items-center rounded-[8px] border p-4 desktop:border-0 desktop:p-0'>
+                <dt className='mr-5 whitespace-nowrap font-bold text-secondary-amber desktop:mr-10 desktop:w-[180px]'>
+                  {label}
+                </dt>
+                <dd className='text-coolgray-500 whitespace-nowrap font-bold'>{data[key]}</dd>
               </dl>
             </li>
           );
         })}
       </ul>
-      <Button size='fixed' onClick={() => toggleModal(USER_META_DATA)}>
-        수정하기
-      </Button>
+      <div className='hidden desktop:block'>
+        <Button size='fixed' onClick={() => toggleModal(USER_META_DATA)}>
+          수정하기
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/features/my-page/my-info.tsx
+++ b/src/features/my-page/my-info.tsx
@@ -39,7 +39,7 @@ const MyInfo = ({ session }: Props) => {
 
   return (
     <section className='flex w-full flex-1 flex-col gap-4'>
-      <Typography as='h2' size='2xl' weight='bold'>
+      <Typography as='h2' className='mobile:text-lg text-2xl font-bold'>
         <div className='flex items-center'>
           <span className='text-primary-orange-600'>내 정보</span> 확인
           <div className='ml-3 desktop:hidden' onClick={() => toggleModal(USER_META_DATA)}>
@@ -47,19 +47,21 @@ const MyInfo = ({ session }: Props) => {
           </div>
         </div>
       </Typography>
-      {!data ? (
-        <div className='flex flex-1 items-center justify-center py-4 desktop:py-0'>
-          <BlockComponent
-            firstLine='이런! 내 정보가 없어요!'
-            secondLine='내 정보를 등록해볼까요?'
-            thirdLine='ChickMate와 함께 성장해요.'
-            buttonName='내 정보 등록하기'
-            onClick={() => toggleModal(USER_META_DATA)}
-          />
-        </div>
-      ) : (
-        <MyInfoContent data={data} />
-      )}
+      <div className='mobile:hidden'>
+        {!data ? (
+          <div className='flex flex-1 items-center justify-center py-4 desktop:py-0'>
+            <BlockComponent
+              firstLine='이런! 내 정보가 없어요!'
+              secondLine='내 정보를 등록해볼까요?'
+              thirdLine='ChickMate와 함께 성장해요.'
+              buttonName='내 정보 등록하기'
+              onClick={() => toggleModal(USER_META_DATA)}
+            />
+          </div>
+        ) : (
+          <MyInfoContent data={data} />
+        )}
+      </div>
       {isModalOpen && (
         <Modal modalId={USER_META_DATA}>
           <UserMetaDataModal />

--- a/src/features/my-page/my-info.tsx
+++ b/src/features/my-page/my-info.tsx
@@ -10,6 +10,7 @@ import UserMetaDataModal from '@/features/user-meta-data/user-meta-data-modal';
 import { useModalStore } from '@/store/use-modal-store';
 import { Session } from 'next-auth';
 import LoadingAnimation from '@/components/common/loading-animation';
+import SettingFill from '@/components/icons/setting-fill';
 
 type Props = {
   session: Session;
@@ -37,12 +38,17 @@ const MyInfo = ({ session }: Props) => {
     );
 
   return (
-    <section className='flex flex-1 flex-col gap-4'>
+    <section className='flex w-full flex-1 flex-col gap-4'>
       <Typography as='h2' size='2xl' weight='bold'>
-        <span className='text-primary-orange-600'>내 정보</span> 확인
+        <div className='flex items-center'>
+          <span className='text-primary-orange-600'>내 정보</span> 확인
+          <div className='ml-3 desktop:hidden' onClick={() => toggleModal(USER_META_DATA)}>
+            <SettingFill />
+          </div>
+        </div>
       </Typography>
       {!data ? (
-        <div className='flex flex-1 items-center justify-center'>
+        <div className='flex flex-1 items-center justify-center py-4 desktop:py-0'>
           <BlockComponent
             firstLine='이런! 내 정보가 없어요!'
             secondLine='내 정보를 등록해볼까요?'

--- a/src/features/my-page/tab-buttons.tsx
+++ b/src/features/my-page/tab-buttons.tsx
@@ -52,17 +52,19 @@ const TabButtons = ({ userId, initialTabCounts }: Props) => {
           <li
             key={`tab_${tab.id}`}
             className={clsx(
-              'text-md h-full w-1/3 px-4 py-[14px] text-center font-bold text-cool-gray-900',
+              'text-md mobile:text-sm h-full w-1/3 px-4 py-[14px] text-center font-bold text-cool-gray-900',
               isCurrentTab && 'border-b-2 border-b-primary-orange-600'
             )}
           >
-            <button className='w-full' onClick={() => handleChangeTab(tab.id)}>
+            <button className='flex w-full items-center justify-center' onClick={() => handleChangeTab(tab.id)}>
               {tab.title}
-              {tabCounts[tab.id] !== 0 && (
-                <Badge mx={1} size='small' color={isCurrentTab ? 'primary' : 'dark'}>
-                  {tabCounts[tab.id]}
-                </Badge>
-              )}
+              <div className='mobile:sr-only'>
+                {tabCounts[tab.id] !== 0 && (
+                  <Badge mx={1} size='small' color={isCurrentTab ? 'primary' : 'dark'}>
+                    {tabCounts[tab.id]}
+                  </Badge>
+                )}
+              </div>
             </button>
           </li>
         );

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -37,7 +37,7 @@ const TabsField = async ({ userId }: Props) => {
   const initialTabCounts = result?._count ?? INIT_TAB_COUNTS;
 
   return (
-    <section className='h-full w-1/2 min-w-[440px] max-w-[634px] overflow-hidden rounded-t-[8px] border bg-cool-gray-10'>
+    <section className='h-full w-full overflow-hidden rounded-t-[8px] border desktop:w-1/2 desktop:min-w-[440px] desktop:max-w-[634px]'>
       <TabButtons userId={userId} initialTabCounts={initialTabCounts} />
       <div className='h-full p-8'>
         <ListByTab />

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -37,9 +37,9 @@ const TabsField = async ({ userId }: Props) => {
   const initialTabCounts = result?._count ?? INIT_TAB_COUNTS;
 
   return (
-    <section className='mobile: h-full w-full overflow-hidden rounded-t-[8px] border desktop:w-1/2 desktop:min-w-[440px] desktop:max-w-[634px]'>
+    <section className='w-full overflow-hidden rounded-t-[8px] border desktop:w-1/2 desktop:min-w-[440px] desktop:max-w-[634px]'>
       <TabButtons userId={userId} initialTabCounts={initialTabCounts} />
-      <div className='mobile:p-4 h-full p-8'>
+      <div className='h-full p-8 mobile:p-4'>
         <ListByTab />
       </div>
     </section>

--- a/src/features/my-page/tabs-field.tsx
+++ b/src/features/my-page/tabs-field.tsx
@@ -1,10 +1,10 @@
-import { prisma } from '@/lib/prisma';
-import type { User } from '@prisma/client';
+import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
+import { INIT_TAB_COUNTS, TABS } from '@/constants/my-page-constants';
+import { RESUME_STATUS } from '@/constants/resume-constants';
 import ListByTab from '@/features/my-page/list-by-tab';
 import TabButtons from '@/features/my-page/tab-buttons';
-import { INIT_TAB_COUNTS, TABS } from '@/constants/my-page-constants';
-import { INTERVIEW_HISTORY_STATUS } from '@/constants/interview-constants';
-import { RESUME_STATUS } from '@/constants/resume-constants';
+import { prisma } from '@/lib/prisma';
+import type { User } from '@prisma/client';
 
 const { COMPLETED } = INTERVIEW_HISTORY_STATUS;
 const { SUBMIT } = RESUME_STATUS;
@@ -37,9 +37,9 @@ const TabsField = async ({ userId }: Props) => {
   const initialTabCounts = result?._count ?? INIT_TAB_COUNTS;
 
   return (
-    <section className='h-full w-full overflow-hidden rounded-t-[8px] border desktop:w-1/2 desktop:min-w-[440px] desktop:max-w-[634px]'>
+    <section className='mobile: h-full w-full overflow-hidden rounded-t-[8px] border desktop:w-1/2 desktop:min-w-[440px] desktop:max-w-[634px]'>
       <TabButtons userId={userId} initialTabCounts={initialTabCounts} />
-      <div className='h-full p-8'>
+      <div className='mobile:p-4 h-full p-8'>
         <ListByTab />
       </div>
     </section>

--- a/src/features/my-page/viewing-field.tsx
+++ b/src/features/my-page/viewing-field.tsx
@@ -22,7 +22,12 @@ const ViewingField = ({ session }: Props) => {
   const userId = session?.user.id ?? null;
   if (!userId) return null;
   return (
-    <section className={clsx('min-width-[634px] flex w-1/2 flex-col self-center', targetId ? 'h-full' : 'h-fit')}>
+    <section
+      className={clsx(
+        'desktop:min-width-[634px] flex w-full flex-col self-center desktop:w-1/2',
+        targetId ? 'h-full' : 'h-fit'
+      )}
+    >
       {!targetId && (
         <>
           <div className='mb-8 flex w-full items-center justify-center'>

--- a/src/features/resume-list/resume-item.tsx
+++ b/src/features/resume-list/resume-item.tsx
@@ -1,6 +1,7 @@
 import { formatDate } from '@/utils/format-date';
 import Typography from '@/components/ui/typography';
 import type { ResumeType } from '@/types/DTO/resume-dto';
+import clsx from 'clsx';
 
 type Props = {
   resume: ResumeType;
@@ -13,26 +14,23 @@ const ResumeItem = ({ resume, onClick, hrOption = true }: Props) => {
   const hasNotInterviewed = tryCount === 0;
 
   return (
-    <div className='flex flex-col gap-4'>
-      <li onClick={() => onClick(id)} className='flex cursor-pointer flex-col'>
-        <Typography size='sm' weight='normal' color='gray-500'>
-          {formatDate({ input: createdAt })}
-        </Typography>
-        <div className='flex items-end justify-between'>
-          <Typography weight='bold'>{title}</Typography>
-          {hasNotInterviewed ? (
-            <Typography size='sm' weight='bold' color='gray-500'>
-              면접 보기 전
-            </Typography>
-          ) : (
-            <Typography size='sm' weight='bold' color='primary-600'>
-              {tryCount}회 면접 완료
-            </Typography>
-          )}
-        </div>
-      </li>
-      {hrOption && <hr className='border-cool-gray-300' />}
-    </div>
+    <li onClick={() => onClick(id)} className={clsx(hrOption && 'border-b', 'cursor-pointer py-2')}>
+      <Typography size='sm' weight='normal' color='gray-500'>
+        {formatDate({ input: createdAt })}
+      </Typography>
+      <div className='flex items-end justify-between'>
+        <Typography weight='bold'>{title}</Typography>
+        {hasNotInterviewed ? (
+          <Typography size='sm' as='span' weight='bold' color='gray-500'>
+            면접 보기 전
+          </Typography>
+        ) : (
+          <Typography size='sm' weight='bold' as='span' color='primary-600'>
+            {tryCount}회 면접 완료
+          </Typography>
+        )}
+      </div>
+    </li>
   );
 };
 

--- a/src/features/resume-list/resume-list.tsx
+++ b/src/features/resume-list/resume-list.tsx
@@ -28,9 +28,16 @@ const ResumeList = () => {
   if (isError) return <div>자소서 리스트를 불러오는데 실패하였습니다.</div>;
 
   return (
-    <ul className='flex h-full flex-col gap-4 overflow-scroll scrollbar-hide'>
-      {resumeList.map((resume) => {
-        return <ResumeItem key={resume.id} resume={resume} onClick={handleGetDetailList} />;
+    <ul className='h-full overflow-y-auto scrollbar-hide'>
+      {resumeList.map((resume, index) => {
+        return (
+          <ResumeItem
+            key={resume.id}
+            resume={resume}
+            hrOption={resumeList.length !== index + 1}
+            onClick={handleGetDetailList}
+          />
+        );
       })}
     </ul>
   );

--- a/src/features/user-meta-data/user-meta-data-form.tsx
+++ b/src/features/user-meta-data/user-meta-data-form.tsx
@@ -25,7 +25,7 @@ const UserMetaDataForm = () => {
   if (isPending) return <LoadingAnimation />;
 
   return (
-    <div className={clsx('mt-10', isFirstTime && 'mt-0')}>
+    <div className={clsx('mobile:mt-4 mt-10', isFirstTime && 'mt-0')}>
       {isFirstTime && (
         <span className='mb-4 block text-center font-bold text-primary-orange-600'>
           작성 완료 시 {FILL_OUT_META_DATA_EXP} 경험치 획득!

--- a/src/features/user-meta-data/user-meta-data-modal.tsx
+++ b/src/features/user-meta-data/user-meta-data-modal.tsx
@@ -4,7 +4,7 @@ import Typography from '@/components/ui/typography';
 const UserMetaDataModal = () => {
   return (
     <section>
-      <Typography as='h2' size='2xl' align='center' weight='bold'>
+      <Typography as='h2' className='mobile:text-xl text-center text-2xl font-bold'>
         내 정보 등록하기
       </Typography>
       <UserMetaDataForm />

--- a/src/features/user-meta-data/user-meta-data-modal.tsx
+++ b/src/features/user-meta-data/user-meta-data-modal.tsx
@@ -5,7 +5,7 @@ const UserMetaDataModal = () => {
   return (
     <section>
       <Typography as='h2' size='2xl' align='center' weight='bold'>
-        주요 이력 작성하기
+        내 정보 등록하기
       </Typography>
       <UserMetaDataForm />
     </section>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,9 @@ const config: Config = {
       maxWidth: {
         max: '1920px',
       },
+      maxWidth: {
+        max: '1920px',
+      },
       colors: {
         'primary-orange': {
           '600': '#E55A27',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,9 +19,6 @@ const config: Config = {
       maxWidth: {
         max: '1920px',
       },
-      maxWidth: {
-        max: '1920px',
-      },
       colors: {
         'primary-orange': {
           '600': '#E55A27',


### PR DESCRIPTION
## 💡 관련이슈

#235 

## 🍀 작업 요약

- 마이페이지 태블릿, 모바일 반응형 적용하였습니다.
- 현재 마이페이지 > 내 자소서 리스트가 많아질 경우 스크롤이 짤리는 문제가 발생하고 있습니다.
- 내 자소서 리스트는 무한스크롤로 구현되어 있지 않은데 이것이 원인일 거 같진 않지만
- 반응형 작업이 끝난 후 리팩토링 진행하면서 같이 해결하겠습니다.
- 해당 내용 참고하시어 리뷰 부탁드립니다.

## 💬 리뷰 요구 사항

- 마이페이지가 태블릿, 모바일 사이즈에서 화면이 깨지지 않는지 확인 부탁드립니다.
- 더불어 마이페이지 내의 모달도 잘 나오는지 확인 부탁드립니다.

## 💛 미리보기

- desktop
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/e03c30c3-e3b5-4a29-aa75-ba19212bb61d" />

- tablet ( -> IPad Mini )
<img width="564" alt="image" src="https://github.com/user-attachments/assets/45e0f80b-7b43-4815-846e-b112b72f154b" />

- mobile ( IPhone XR )
<img width="351" alt="image" src="https://github.com/user-attachments/assets/76106376-09a4-4130-877c-754f1526716d" />


### ✔️ 이슈 닫기

Closes #235 
Ref #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝나지 않은 경우


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
    - 다양한 컴포넌트 및 페이지에 모바일 및 데스크톱 반응형 스타일이 개선되었습니다.
    - 버튼, 텍스트, 카드, 리스트 등에서 폰트 크기, 간격, 배경, 보더 등 UI 요소의 시각적 일관성과 접근성이 향상되었습니다.
    - 설정 아이콘, 뱃지, 버튼 등 일부 요소의 모바일/데스크톱 노출 방식이 변경되었습니다.

- **신규 기능**
    - 이력서 삭제 시 커스텀 확인 모달과 성공/실패 알림이 제공됩니다.

- **버그 수정**
    - 빈 사용자 정보 필드는 더 이상 표시되지 않습니다.

- **리팩터**
    - 일부 컴포넌트의 JSX 구조가 단순화되고, 불필요한 중첩이 제거되었습니다.

- **환경설정**
    - Tailwind CSS의 반응형 브레이크포인트 및 최대 너비 설정이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->