### PR TITLE
bugfix:#260 컴포넌트가 마운트된 이후에 렌더링하도록 설정

### DIFF
--- a/src/features/home/render-home.tsx
+++ b/src/features/home/render-home.tsx
@@ -4,10 +4,17 @@ import DesktopHome from '@/features/home/desktop-home';
 import TabletHome from '@/features/home/tablet-home';
 import MobileHome from './mobile-home';
 import LoadingAnimation from '@/components/common/loading-animation';
+import { useEffect, useState } from 'react';
 const { MOBILE, TABLET, DESKTOP } = DEVICE;
 const RenderHome = () => {
+  const [isMounted, setIsMounted] = useState(false);
   const device = useDeviceType();
-  if (!device) return <LoadingAnimation />;
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) return <></>;
+
   switch (device) {
     case DESKTOP:
       return <DesktopHome />;


### PR DESCRIPTION
## 💡 관련이슈

#260 

## 🍀 작업 요약

-메인 페이지 -> 온보딩 페이지 이동 시 link 한 번만 클릭해도 바로 이동되도록 수정 

## 💬 에러 원인

- 부모 컴포넌트인 서버 컴포넌트에서는 처음에 디바이스 타입을 알 수 없음
- `useDeviceType` hook내부의 `getDeviceType`함수에 의해 초기값은 null
- `if (!device) return <LoadingAnimation />;` 조건문이 충족되어 로직이 실행되지만 서버컴포넌트에서 LoadingAnimation 사용불가
- 결론 : **hydration** 오류 발생

## 🙌 해결

- 로딩 UI 대신 빈 태그를 초기에 렌더링
- 메인 페이지를 그릴 수 있는 클라이언트 컴포넌트가 완전이 렌더링되고 난 이후에 device 타입에 따라 알맞은 컴포넌트가 렌더링 되도록 수정

### ✔️ 이슈 닫기

Closes #260 
Ref #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝나지 않은 경우


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 홈 화면에서 초기 마운트 시 로딩 애니메이션이 더 이상 표시되지 않으며, 컴포넌트가 마운트된 후에만 화면이 렌더링됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->