### PR TITLE
Hotfix/#264 resume list status error

### DIFF
--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -35,10 +35,6 @@ export const GET = async (request: NextRequest) => {
       },
     });
 
-    if (!response) {
-      return NextResponse.json({ message: NOT_FOUND }, { status: 404 });
-    }
-
     return NextResponse.json({ response }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ message: GET_SERVER_ERROR }, { status: 500 });

--- a/src/features/interview/resume-all-modal.tsx
+++ b/src/features/interview/resume-all-modal.tsx
@@ -58,7 +58,6 @@ const ResumeAllModal = () => {
                   setResume(resume.id);
                   toggleModal(ALL_RESUME_LIST);
                 }}
-                hrOption={false}
               />
             );
           })}

--- a/src/features/interview/resume-cards-box.tsx
+++ b/src/features/interview/resume-cards-box.tsx
@@ -67,10 +67,14 @@ const ResumeCardsBox = ({ session }: Props) => {
       </section>
       <section className='hidden max-h-[200px] max-w-[100vw] flex-col gap-5 mobile:flex'>
         <ul className='flex w-full flex-col overflow-y-auto scrollbar-hide'>
-          {resumeList.map((resume) => {
+          {resumeList.map((resume, index) => {
             return (
               <div key={resume.id} className={`${resume.id === selectedId ? 'bg-primary-orange-600/20' : ''} `}>
-                <ResumeItem resume={resume} onClick={() => setResume(resume.id)} hrOption={false} />
+                <ResumeItem
+                  resume={resume}
+                  onClick={() => setResume(resume.id)}
+                  isLastChild={resumeList.length === index + 1}
+                />
               </div>
             );
           })}

--- a/src/features/my-page/empty-list.tsx
+++ b/src/features/my-page/empty-list.tsx
@@ -2,11 +2,9 @@ import { TABS } from '@/constants/my-page-constants';
 
 const { BOOKMARK_TAB, RESUME_TAB, INTERVIEW_HISTORY_TAB } = TABS;
 const EMPTY_MESSAGE: Record<string, string> = {
-  [INTERVIEW_HISTORY_TAB]: `면접 결과가 없습니다.
-  면접을 먼저 진행해 주세요.`,
-  [BOOKMARK_TAB]: `북마크 된 채용 공고가 없습니다.
-  채용공고 페이지에서 원하는 내용을 찾아보세요.`,
-  [RESUME_TAB]: `아직 작성된 이력서가 없습니다.`,
+  [INTERVIEW_HISTORY_TAB]: `면접 결과가 없습니다.\n면접을 먼저 진행해 주세요.`,
+  [BOOKMARK_TAB]: `북마크 된 채용 공고가 없습니다.\n채용공고 페이지에서 원하는 내용을 찾아보세요.`,
+  [RESUME_TAB]: `아직 작성된 자소서가 없습니다.\n자소서를 먼저 작성해 주세요.`,
 };
 
 type Props = {

--- a/src/features/resume-list/resume-item.tsx
+++ b/src/features/resume-list/resume-item.tsx
@@ -6,15 +6,15 @@ import clsx from 'clsx';
 type Props = {
   resume: ResumeType;
   onClick: (resumeId: ResumeType['id']) => void;
-  hrOption?: boolean;
+  isLastChild?: boolean;
 };
 
-const ResumeItem = ({ resume, onClick, hrOption = true }: Props) => {
+const ResumeItem = ({ resume, onClick, isLastChild = true }: Props) => {
   const { id, title, createdAt, tryCount } = resume;
   const hasNotInterviewed = tryCount === 0;
 
   return (
-    <div className='flex flex-col mobile:p-2 gap-4'>
+    <div className={clsx('flex flex-col gap-4 py-2 mobile:p-2', isLastChild ? 'border-b-0' : 'border-b')}>
       <li onClick={() => onClick(id)} className='flex cursor-pointer flex-col'>
         <Typography size='sm' weight='normal' color='gray-500'>
           <span className='mobile:text-xs'>{formatDate({ input: createdAt })}</span>
@@ -34,7 +34,6 @@ const ResumeItem = ({ resume, onClick, hrOption = true }: Props) => {
           )}
         </div>
       </li>
-      {hrOption && <hr className='border-cool-gray-300' />}
     </div>
   );
 };

--- a/src/features/resume-list/resume-list.tsx
+++ b/src/features/resume-list/resume-list.tsx
@@ -35,7 +35,7 @@ const ResumeList = () => {
           <ResumeItem
             key={resume.id}
             resume={resume}
-            hrOption={resumeList.length !== index + 1}
+            isLastChild={resumeList.length === index + 1}
             onClick={handleGetDetailList}
           />
         );

--- a/src/features/resume-list/resume-list.tsx
+++ b/src/features/resume-list/resume-list.tsx
@@ -5,6 +5,7 @@ import ResumeItem from '@/features/resume-list/resume-item';
 import { useResumeListQuery } from '@/features/resume-list/hooks/use-resume-list-query';
 import { getMyPagePath } from '@/features/my-page/utils/get-my-page-path';
 import { TABS } from '@/constants/my-page-constants';
+import EmptyList from '../my-page/empty-list';
 
 const { RESUME_TAB } = TABS;
 
@@ -26,7 +27,7 @@ const ResumeList = () => {
   }
 
   if (isError) return <div>자소서 리스트를 불러오는데 실패하였습니다.</div>;
-
+  if (resumeList.length === 0) return <EmptyList tab={RESUME_TAB} />;
   return (
     <ul className='h-full overflow-y-auto scrollbar-hide'>
       {resumeList.map((resume, index) => {


### PR DESCRIPTION
## 💡 관련이슈

#264 

## 🍀 작업 요약

- 마이페이지 > 자소서 리스트 없을 시 status 404가 아닌 200으로 수정
- 데이터가 없을 시 `작성한 자소서가 없습니다.~` 문구 노출
- 자소서 리스트 padding 수정

## 💬 리뷰 요구 사항

- 자소서가 없을 시 404 에러 나지 않는지 확인 부탁드립니다.
- `<ResumeItem />`사용하는 제가 한 번씩 확인하긴 했는데 크로스 체크 부탁드립니다.

## 💛 미리보기

- 
<img width="1562" alt="image" src="https://github.com/user-attachments/assets/e2038dc8-cfe2-4dc5-a1fe-351acc2ba24c" />


### ✔️ 이슈 닫기

Closes #264 
Ref #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝나지 않은 경우


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - 이력서 목록이 비어 있을 때 빈 상태 안내 메시지가 표시됩니다.
    - 이력서 항목 구분선이 마지막 항목에서는 표시되지 않도록 개선되었습니다.

- **스타일**
    - 이력서 항목의 구분선 처리가 CSS 클래스로 일관되게 적용되었습니다.
    - 빈 목록 메시지의 문구와 줄바꿈 처리가 개선되었습니다.

- **리팩터**
    - 이력서 항목 관련 prop 명칭이 더 명확하게 변경되었습니다. (hrOption → isLastChild)

- **기타**
    - 이력서 조회 시 데이터가 없더라도 항상 200 응답을 반환하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->