### PR TITLE
style:#236 mobile에서 nav에 home 버튼도 노출되도록 추가

### DIFF
--- a/src/features/layout/data/nav-items.tsx
+++ b/src/features/layout/data/nav-items.tsx
@@ -9,6 +9,7 @@ import InterviewFullIcon from '@/components/icons/interview-full-icon';
 import JobFullIcon from '@/components/icons/job-full-icon';
 import MyPageFullIcon from '@/components/icons/my-page-full-icon';
 import ResumeFullIcon from '@/components/icons/resume-full-icon';
+import { ChickLogo } from '@/components/icons/chick-logo';
 
 export type NavItems = {
   path: string;
@@ -22,6 +23,14 @@ export type NavItems = {
 const { ON_BOARDING, AUTH, MY_PAGE, RESUME, INTERVIEW, JOB } = PATH;
 
 const Nav_Items = [
+  {
+    path: ON_BOARDING,
+    type: 'link',
+    name: 'HOME',
+    icon: <ChickLogo />,
+    fullIcon: <ChickLogo />,
+    class: 'hidden mobile:block',
+  },
   {
     path: RESUME.ROOT,
     type: 'link',


### PR DESCRIPTION
## 💡 관련이슈

#236 

## 🍀 작업 요약

- 모바일 버전에서 nav에 home버튼도 추가하였습니다.

## 💬 리뷰 요구 사항

- 모바일에서 home 버튼이 잘 노출되는지, 온보딩 페이지로 잘 이동이 되는지 확인 부탁드립니다.

## 💛 미리보기
<img width="396" alt="image" src="https://github.com/user-attachments/assets/135fb7e4-d63e-4a67-b005-933e1b62dfbc" />

### ✔️ 이슈 닫기

Closes #236 
Ref #이슈번호 // 해당 이슈에 대한 작업이 완전히 끝나지 않은 경우


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 온보딩 경로로 이동하는 새로운 네비게이션 항목이 추가되었습니다. 이 항목은 "HOME" 이름과 ChickLogo 아이콘을 사용하며, 모바일 환경에서만 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->